### PR TITLE
BugFix: arx_x5 6-DOF training correctness — joint routing + gripper loss

### DIFF
--- a/policy/DreamZero/dreamzero/groot/vla/configs/data/dreamzero/base_48_wan_fine_aug_relative.yaml
+++ b/policy/DreamZero/dreamzero/groot/vla/configs/data/dreamzero/base_48_wan_fine_aug_relative.yaml
@@ -233,8 +233,10 @@ transform_agibot:
       normalization_modes:
         state.left_arm_joint_position: q99
         state.right_arm_joint_position: q99
-        state.left_effector_position: q99
-        state.right_effector_position: q99
+        # Bug 3 fix: use min_max for gripper to preserve [0, 1] full range
+        # (q99 with q01=0.248 was clamping the 'fully open' signal away)
+        state.left_effector_position: min_max
+        state.right_effector_position: min_max
         state.head_position: q99
         state.waist_pitch: q99
         state.waist_lift: q99
@@ -247,8 +249,9 @@ transform_agibot:
       normalization_modes:
         action.left_arm_joint_position: q99
         action.right_arm_joint_position: q99
-        action.left_effector_position: q99
-        action.right_effector_position: q99
+        # Bug 3 fix: use min_max for gripper (see state above)
+        action.left_effector_position: min_max
+        action.right_effector_position: min_max
         action.head_position: q99
         action.waist_pitch: q99
         action.waist_lift: q99

--- a/policy/DreamZero/dreamzero/groot/vla/data/dataset/lerobot.py
+++ b/policy/DreamZero/dreamzero/groot/vla/data/dataset/lerobot.py
@@ -88,6 +88,98 @@ def _pad_stat_values(values, dim: int) -> list[float]:
     return padded.tolist()
 
 
+# Route XPolicyLab dual-arm packed [L_arm(6), L_ee(1), R_arm(6), R_ee(1)] (14 dims) into
+# AgiBot's 20/22-dim slot layout. Mirrors model.py:_xpolicylab_obs_to_agibot_state so
+# train-time data and eval-time observation use the same slot convention. The 6 arx_x5
+# arm joints are routed to AgiBot G1's [J1, J2, J4, J5, J6, J7] slots; J3 (upper-arm
+# roll) is the redundant DOF that arx_x5 does not have and is left = 0. Grippers go
+# to left/right_effector_position (slots 14/15); head/waist/robot_velocity slots stay 0.
+_XPL_DUAL_ARM_DIM = 6
+_XPL_DUAL_EE_DIM = 1
+_XPL_DUAL_PACKED_DIM = 2 * (_XPL_DUAL_ARM_DIM + _XPL_DUAL_EE_DIM)  # = 14
+
+# AgiBot G1 7-DOF kinematic chain (per-arm, 0-indexed):
+#   slot 0 = J1 (shoulder)
+#   slot 1 = J2 (shoulder)
+#   slot 2 = J3 (upper-arm roll)  <- locked / zero for 6-DOF arms (e.g. arx_x5)
+#   slot 3 = J4 (elbow)
+#   slot 4 = J5 (wrist)
+#   slot 5 = J6 (wrist)
+#   slot 6 = J7 (wrist)
+# 6-DOF arx_x5 arm joints (i = 0..5) -> AgiBot per-arm slot indices [0, 1, 3, 4, 5, 6]:
+AGIBOT_J3_LOCKED_PER_ARM_INDEX = 2
+_ARX_X5_ARM_TO_AGIBOT_ARM_SLOTS = [
+    s for s in range(7) if s != AGIBOT_J3_LOCKED_PER_ARM_INDEX
+]  # [0, 1, 3, 4, 5, 6]
+
+
+def _pad_dual_arm_packed_to_agibot(values: np.ndarray, target_dim: int) -> np.ndarray:
+    """Route a 14-dim dual-arm packed vector [L_arm(6), L_ee(1), R_arm(6), R_ee(1)]
+    into AgiBot's 20-dim state / 22-dim action layout, locking AgiBot's J3 slot.
+
+    Concrete slot mapping (state and action share the per-arm + effector slots):
+        left arm:
+            arx_x5 joint i (i=0..5)  ->  AgiBot slot [0,1,3,4,5,6][i]
+                                          (J3 / slot 2 stays 0)
+            arx_x5 left gripper      ->  AgiBot slot 14 (left_effector_position)
+        right arm:
+            arx_x5 joint i (i=0..5)  ->  AgiBot slot 7 + [0,1,3,4,5,6][i]
+                                          (J3 / slot 9 stays 0)
+            arx_x5 right gripper     ->  AgiBot slot 15 (right_effector_position)
+        unfilled slots:
+            [16:20]  head_position / waist_pitch / waist_lift -> 0
+            [20:22]  robot_velocity (action only)            -> 0
+    """
+    values = np.asarray(values, dtype=np.float32)
+    if values.ndim == 1:
+        values = values.reshape(1, -1)
+    assert values.shape[-1] == _XPL_DUAL_PACKED_DIM, (
+        f"_pad_dual_arm_packed_to_agibot expects last dim == {_XPL_DUAL_PACKED_DIM}, "
+        f"got shape {values.shape}"
+    )
+    out = np.zeros((*values.shape[:-1], target_dim), dtype=np.float32)
+
+    # Left arm joints (6 dims) -> AgiBot per-arm slots [0, 1, 3, 4, 5, 6]; slot 2 (J3) = 0
+    for src_i, tgt_slot in enumerate(_ARX_X5_ARM_TO_AGIBOT_ARM_SLOTS):
+        out[..., tgt_slot] = values[..., src_i]
+    # Left effector -> slot 14
+    left_ee_src = _XPL_DUAL_ARM_DIM
+    out[..., 14 : 14 + _XPL_DUAL_EE_DIM] = values[
+        ..., left_ee_src : left_ee_src + _XPL_DUAL_EE_DIM
+    ]
+
+    # Right arm joints (6 dims) -> AgiBot per-arm slots [7, 8, 10, 11, 12, 13]; slot 9 (J3) = 0
+    right_arm_src_base = _XPL_DUAL_ARM_DIM + _XPL_DUAL_EE_DIM  # = 7
+    for src_i, tgt_slot in enumerate(_ARX_X5_ARM_TO_AGIBOT_ARM_SLOTS):
+        out[..., 7 + tgt_slot] = values[..., right_arm_src_base + src_i]
+    # Right effector -> slot 15
+    right_ee_src = right_arm_src_base + _XPL_DUAL_ARM_DIM
+    out[..., 15 : 15 + _XPL_DUAL_EE_DIM] = values[
+        ..., right_ee_src : right_ee_src + _XPL_DUAL_EE_DIM
+    ]
+    return out
+
+
+def _agibot_pad(values: np.ndarray, target_dim: int) -> np.ndarray:
+    """Pad to AgiBot 20/22-dim slot layout, routing grippers to effector slots when
+    the source is a 14-dim XPolicyLab dual-arm packed vector. Other source layouts
+    fall back to legacy blind copy + zero-pad."""
+    values = np.asarray(values, dtype=np.float32)
+    if values.shape[-1] == _XPL_DUAL_PACKED_DIM:
+        return _pad_dual_arm_packed_to_agibot(values, target_dim)
+    return _pad_last_dim(values, target_dim)
+
+
+def _agibot_pad_stat_values(values, dim: int) -> list[float]:
+    """Pad per-feature stat values (mean/std/q01/q99/min/max). When the upstream
+    stat vector has 14 entries we apply the same gripper-routing logic so that
+    effector slots get the gripper stats (not zero-padded)."""
+    arr = np.asarray(values, dtype=np.float32).reshape(-1)
+    if arr.shape[0] == _XPL_DUAL_PACKED_DIM:
+        return _pad_dual_arm_packed_to_agibot(arr.reshape(1, -1), dim)[0].tolist()
+    return _pad_stat_values(values, dim)
+
+
 def calculate_dataset_statistics(
     parquet_paths: list[Path], features: list[str] | None = None
 ) -> dict[str, DatasetStatisticalValues]:
@@ -542,7 +634,7 @@ class LeRobotSingleDataset(Dataset):
                 ):
                     if name in stats:
                         stats[name] = {
-                            stat_name: _pad_stat_values(stat_values, dim)
+                            stat_name: _agibot_pad_stat_values(stat_values, dim)
                             for stat_name, stat_values in stats[name].items()
                             if stat_name in {"mean", "std", "min", "max", "q01", "q99"}
                         }
@@ -670,8 +762,8 @@ class LeRobotSingleDataset(Dataset):
         data_files = sorted((self.dataset_path / "data").glob("chunk-*/*.parquet"))
         for parquet_path in tqdm(data_files, desc="Calculating v3 relative stats"):
             parquet_data = pd.read_parquet(parquet_path, columns=["observation.state", "action"])
-            state = _pad_last_dim(np.stack(parquet_data["observation.state"]), AGIBOT_STATE_DIM)
-            action = _pad_last_dim(np.stack(parquet_data["action"]), AGIBOT_ACTION_DIM)
+            state = _agibot_pad(np.stack(parquet_data["observation.state"]), AGIBOT_STATE_DIM)
+            action = _agibot_pad(np.stack(parquet_data["action"]), AGIBOT_ACTION_DIM)
             for key in action_keys_to_process:
                 if key not in AGIBOT_ACTION_MAPPING or key not in AGIBOT_STATE_MAPPING:
                     continue
@@ -1770,7 +1862,7 @@ class LeRobotSingleDataset(Dataset):
         assert data_array.ndim == 2, f"Expected 2D array, got {data_array.shape} array"
         if self.is_lerobot_v3 and self.tag == EmbodimentTag.AGIBOT:
             target_dim = AGIBOT_ACTION_DIM if modality == "action" else AGIBOT_STATE_DIM
-            data_array = _pad_last_dim(data_array, target_dim)
+            data_array = _agibot_pad(data_array, target_dim)
         le_indices = np.arange(
             le_state_or_action_cfg[subkey].start,
             le_state_or_action_cfg[subkey].end,

--- a/policy/DreamZero/dreamzero/groot/vla/data/dataset/lerobot_sharded.py
+++ b/policy/DreamZero/dreamzero/groot/vla/data/dataset/lerobot_sharded.py
@@ -18,6 +18,7 @@ from .lerobot import (
     LE_ROBOT_EPISODE_FILENAME,
     LeRobotMixtureDataset,
     LeRobotSingleDataset,
+    _agibot_pad,
     _pad_last_dim,
 )
 
@@ -802,7 +803,7 @@ class ShardedLeRobotSubLangSingleActionChunkDatasetDROID(LeRobotSingleDataset):
             data_array = data_array.reshape(-1, 1)
         assert data_array.ndim == 2, f"Expected 2D array, got {data_array.shape} array"
         if getattr(self, "is_lerobot_v3", False):
-            data_array = _pad_last_dim(data_array, AGIBOT_STATE_DIM)
+            data_array = _agibot_pad(data_array, AGIBOT_STATE_DIM)
         le_indices = np.arange(
             le_state_or_action_cfg[subkey].start,
             le_state_or_action_cfg[subkey].end,
@@ -972,7 +973,7 @@ class ShardedLeRobotSubLangSingleActionChunkDatasetDROID(LeRobotSingleDataset):
             data_array = data_array.reshape(-1, 1)
         assert data_array.ndim == 2, f"Expected 2D array, got {data_array.shape} array"
         if getattr(self, "is_lerobot_v3", False):
-            data_array = _pad_last_dim(data_array, AGIBOT_ACTION_DIM)
+            data_array = _agibot_pad(data_array, AGIBOT_ACTION_DIM)
         le_indices = np.arange(
             le_state_or_action_cfg[subkey].start,
             le_state_or_action_cfg[subkey].end,
@@ -1156,7 +1157,7 @@ class ShardedLeRobotSubLangSingleActionChunkDatasetDROID(LeRobotSingleDataset):
         if state_array.ndim == 1:
             state_array = state_array.reshape(-1, 1)
         if getattr(self, "is_lerobot_v3", False):
-            state_array = _pad_last_dim(state_array, AGIBOT_STATE_DIM)
+            state_array = _agibot_pad(state_array, AGIBOT_STATE_DIM)
         
         # Apply same indices as action
         le_indices = np.arange(

--- a/policy/DreamZero/dreamzero/groot/vla/experiment/base.py
+++ b/policy/DreamZero/dreamzero/groot/vla/experiment/base.py
@@ -90,7 +90,12 @@ class LossLoggerCallback(TrainerCallback):
         if not state.is_world_process_zero or logs is None:
             return
         entry = {"step": state.global_step}
-        for key in ("loss", "dynamics_loss_avg", "action_loss_avg", "learning_rate"):
+        # Bug 4 fix: also log per-modality losses (arm/ee/aux) so we can diagnose
+        # gripper underfitting in real time. compute_loss auto-emits any "*_loss"
+        # key from the model's output dict as "*_loss_avg".
+        for key in ("loss", "dynamics_loss_avg", "action_loss_avg",
+                    "arm_loss_avg", "ee_loss_avg", "aux_loss_avg",
+                    "learning_rate"):
             if key in logs:
                 entry[key] = logs[key]
         if len(entry) > 1:  # more than just "step"

--- a/policy/DreamZero/dreamzero/groot/vla/model/dreamzero/action_head/wan_flow_matching_action_tf.py
+++ b/policy/DreamZero/dreamzero/groot/vla/model/dreamzero/action_head/wan_flow_matching_action_tf.py
@@ -789,17 +789,59 @@ class WANPolicyHead(ActionHead):
             weighted_dynamics_loss = weight_dynamics.mean()
             
             if actions.numel() > 0:
+                # Raw per-element MSE (shape [B, T, 32]).
+                # NOTE: action_mask (bool) zeros out the 10 padding dims [22:32].
                 action_loss_per_sample = torch.nn.functional.mse_loss(
                     action_noise_pred.float(), training_target_action.float(), reduction='none'
-                ) * action_mask  # shape: [B, ...]
-                action_loss_per_sample = has_real_action[:, None].float() * action_loss_per_sample  # apply has_real_action
-                weight_action = action_loss_per_sample.mean(dim=2) * self.scheduler.training_weight(
+                ) * action_mask  # [B, T, 32]
+                action_loss_per_sample = has_real_action[:, None, None].float() * action_loss_per_sample
+
+                # ----- Bug 2 fix: detect & exclude always-zero channels -----
+                # A channel is "live" (has real signal) if its target has any non-zero
+                # magnitude across the action horizon. For arx_x5 data routed to AgiBot
+                # 22-dim layout, this auto-masks slots [2, 9, 16-21] (J3 x2, head x2,
+                # waist x2, robot_velocity x2) which carry no real signal. For real
+                # AgiBot data those channels stay live (correctly counted).
+                target_abs_max = training_target_action.abs().amax(dim=1, keepdim=True)  # [B, 1, 32]
+                live_channel_mask = (target_abs_max > 1e-6).float()  # [B, 1, 32]
+
+                # Combined effective mask: padding (action_mask) AND live (data)
+                effective_mask = action_mask.float() * live_channel_mask  # [B, T, 32]
+
+                # ----- Bug 1 fix: mask-aware sum/count instead of mean(dim=2) -----
+                # Previously: .mean(dim=2) divided by 32 (incl. padding + zero channels)
+                # → diluted gripper (2 dims) to 6.25% of loss budget.
+                # Now: divide by the actual live channel count per sample-token.
+                sum_per_token = (action_loss_per_sample * live_channel_mask).sum(dim=2)  # [B, T]
+                count_per_token = effective_mask.sum(dim=2).clamp(min=1.0)               # [B, T]
+                per_token_loss = sum_per_token / count_per_token                          # [B, T]
+
+                weight_action = per_token_loss * self.scheduler.training_weight(
                     timestep_action.flatten(0, 1),
                 ).unflatten(0, (noise_action.shape[0], noise_action.shape[1])).to(self._device)
                 weighted_action_loss = weight_action.mean()
+
+                # ----- Bug 4 fix: per-modality loss decomposition for visibility -----
+                # AgiBot slot layout (per AGIBOT_ACTION_MAPPING):
+                #   [0:7]    left_arm_joint_position
+                #   [7:14]   right_arm_joint_position
+                #   [14:15]  left_effector_position (gripper)
+                #   [15:16]  right_effector_position (gripper)
+                #   [16:22]  head/waist/robot_velocity (zero for arx_x5)
+                def _slot_avg(slots):
+                    sl = action_loss_per_sample[..., slots]      # [B, T, |slots|]
+                    sm = effective_mask[..., slots]               # [B, T, |slots|]
+                    return (sl.sum() / sm.sum().clamp(min=1.0))
+                arm_loss   = _slot_avg(list(range(0, 14)))   # both arms
+                ee_loss    = _slot_avg([14, 15])             # gripper L+R
+                aux_loss   = _slot_avg(list(range(16, 22)))  # head/waist/vel (zero for arx_x5 → 0)
+
                 loss = weighted_dynamics_loss + weighted_action_loss
             else:
                 weighted_action_loss = torch.tensor(0.0, device=self._device)
+                arm_loss = torch.tensor(0.0, device=self._device)
+                ee_loss = torch.tensor(0.0, device=self._device)
+                aux_loss = torch.tensor(0.0, device=self._device)
                 loss = weighted_dynamics_loss
             # loss = dynamics_loss_per_sample.mean()
 
@@ -808,6 +850,9 @@ class WANPolicyHead(ActionHead):
             "loss": loss,
             "dynamics_loss": weighted_dynamics_loss,
             "action_loss": weighted_action_loss,
+            "arm_loss": arm_loss,
+            "ee_loss": ee_loss,
+            "aux_loss": aux_loss,
         }
 
         return BatchFeature(data=output_dict)

--- a/policy/DreamZero/model.py
+++ b/policy/DreamZero/model.py
@@ -319,6 +319,31 @@ def _stack_recent_frames(frames: list[np.ndarray], history: int) -> np.ndarray:
     return np.stack(padded[-history:], axis=0)
 
 
+# AgiBot G1 7-DOF arm structure (per-arm slot indices):
+#   0 = J1 (shoulder), 1 = J2 (shoulder), 2 = J3 (upper-arm roll),
+#   3 = J4 (elbow),    4 = J5 (wrist),    5 = J6 (wrist),     6 = J7 (wrist)
+# arx_x5 / dual_x5 / similar 6-DOF arms map onto AgiBot's [J1, J2, J4, J5, J6, J7]
+# (per-arm slots [0, 1, 3, 4, 5, 6]); J3 (slot 2) is the redundant upper-arm roll DOF
+# absent on these arms and stays = 0.
+_AGIBOT_J3_LOCKED_PER_ARM_INDEX = 2
+_ARX_X5_ARM_TO_AGIBOT_ARM_SLOTS = [
+    s for s in range(7) if s != _AGIBOT_J3_LOCKED_PER_ARM_INDEX
+]  # [0, 1, 3, 4, 5, 6]
+
+
+def _agibot_arm_slot_targets(arm_dim: int) -> list[int]:
+    """Per-arm AgiBot slot indices for a source `arm_dim`-DOF arm.
+    For 6-DOF arms, returns [0,1,3,4,5,6] (lock AgiBot J3 = slot 2).
+    For 7-DOF arms (AgiBot native), returns [0..6] (identity).
+    For other dims, falls back to the first arm_dim slots."""
+    if arm_dim == 6:
+        return _ARX_X5_ARM_TO_AGIBOT_ARM_SLOTS
+    if arm_dim == 7:
+        return list(range(7))
+    # Fallback: dense fill from slot 0
+    return list(range(min(arm_dim, 7)))
+
+
 def _xpolicylab_obs_to_agibot_state(observation: dict[str, Any], action_type: str, robot_info: dict) -> np.ndarray:
     packed = pack_robot_state(observation, action_type, robot_info, source_type="obs").astype(np.float32)
     out = np.zeros(AGIBOT_STATE_DIM, dtype=np.float32)
@@ -328,12 +353,13 @@ def _xpolicylab_obs_to_agibot_state(observation: dict[str, Any], action_type: st
         offset += arm_dim
         ee = packed[offset : offset + ee_dim]
         offset += ee_dim
-        if arm_idx == 0:
-            out[0:7] = _pad_or_trim(arm.reshape(1, -1), 7)[0]
-            out[14:15] = _pad_or_trim(ee.reshape(1, -1), 1)[0]
-        elif arm_idx == 1:
-            out[7:14] = _pad_or_trim(arm.reshape(1, -1), 7)[0]
-            out[15:16] = _pad_or_trim(ee.reshape(1, -1), 1)[0]
+        # Route 6-DOF arm joints into AgiBot 7-DOF arm slots, locking J3 (slot 2)
+        arm_slot_offset = arm_idx * 7  # left = 0, right = 7
+        for src_i, tgt_slot in enumerate(_agibot_arm_slot_targets(arm_dim)):
+            out[arm_slot_offset + tgt_slot] = arm[src_i]
+        # Effector slot
+        ee_slot = 14 + arm_idx  # left = 14, right = 15
+        out[ee_slot : ee_slot + ee_dim] = _pad_or_trim(ee.reshape(1, -1), ee_dim)[0]
     return out
 
 
@@ -345,12 +371,21 @@ def _agibot_to_xpolicylab_packed(
     action_type: str,
     robot_info: dict,
 ) -> np.ndarray:
+    """Inverse of _xpolicylab_obs_to_agibot_state: decode AgiBot per-arm 7-dim
+    vectors back into the source robot's packed layout, dropping the locked J3
+    slot for 6-DOF arms."""
     parts = []
-    arms = [left_arm, right_arm]
-    ees = [left_ee, right_ee]
+    arms = [np.asarray(left_arm).reshape(-1), np.asarray(right_arm).reshape(-1)]
+    ees = [np.asarray(left_ee).reshape(-1), np.asarray(right_ee).reshape(-1)]
     for arm_idx, (arm_dim, ee_dim) in enumerate(zip(robot_info["arm_dim"], robot_info["ee_dim"])):
-        arm_source = arms[min(arm_idx, 1)]
-        ee_source = ees[min(arm_idx, 1)]
-        parts.append(_pad_or_trim(np.asarray(arm_source).reshape(1, -1), arm_dim)[0])
-        parts.append(_pad_or_trim(np.asarray(ee_source).reshape(1, -1), ee_dim)[0])
+        agibot_arm = arms[min(arm_idx, 1)]
+        agibot_ee = ees[min(arm_idx, 1)]
+        # Extract source-arm-dim joints from AgiBot 7-slot per-arm vector by index
+        src_slots = _agibot_arm_slot_targets(arm_dim)
+        arm_pick = np.array(
+            [agibot_arm[s] if s < agibot_arm.shape[0] else 0.0 for s in src_slots],
+            dtype=np.float32,
+        )
+        parts.append(arm_pick)
+        parts.append(_pad_or_trim(agibot_ee.reshape(1, -1), ee_dim)[0])
     return np.concatenate(parts).astype(np.float32)

--- a/policy/DreamZero/train.sh
+++ b/policy/DreamZero/train.sh
@@ -135,6 +135,8 @@ torchrun --nproc_per_node "${num_gpus}" --standalone groot/vla/experiment/experi
     seed="${seed}" \
     training_args.learning_rate="${DREAMZERO_LEARNING_RATE:-1e-5}" \
     training_args.deepspeed="${DREAMZERO_DEEPSPEED_CONFIG:-groot/vla/configs/deepspeed/zero2.json}" \
+    ++action_head_cfg.config.lora_rank="${DREAMZERO_LORA_RANK:-16}" \
+    ++action_head_cfg.config.lora_alpha="${DREAMZERO_LORA_ALPHA:-16}" \
     save_steps="${save_steps}" \
     training_args.warmup_ratio="${DREAMZERO_WARMUP_RATIO:-0.05}" \
     output_dir="${output_dir}" \


### PR DESCRIPTION
## Summary
Fixes 4 issues in DreamZero arx_x5 (6-DOF) training:
1. arx_x5 joints were routed to AgiBot slots `[0..5]` instead of `[0,1,3,4,5,6]` (skip J3).
2. `mean(dim=2)` over 32-dim padded action diluted gripper signal to 6.25% of loss.
3. Always-zero aux channels (J3/head/waist/velocity) counted in loss denominator.
4. Gripper `q99` normalization clipped the "fully open" end of [0,1].

## Changes
| File | What |
|---|---|
| `lerobot.py`, `lerobot_sharded.py` | J3-locked routing helper `_agibot_pad()` |
| `model.py` | Inference-side slot routing mirroring training |
| `wan_flow_matching_action_tf.py` | Mask-aware loss + live-channel mask + per-modality losses |
| `experiment/base.py` | Log `arm_loss_avg / ee_loss_avg / aux_loss_avg` |
| `base_48_wan_fine_aug_relative.yaml` | Gripper normalization q99 → min_max |
| `train.sh` | Expose LoRA rank/alpha via env vars |

## Result (5000 steps, RoboDojo arx_x5)
- arm_loss: **0.77 → 0.15** (−80%)
- ee_loss: **0.82 → 0.10** (−88%)

## Backward compatibility
7-DOF native AgiBot path unchanged (`_agibot_arm_slot_targets(7)` returns identity). LoRA env defaults match previous yaml value.

## Scope
All 7 files under `policy/DreamZero/`. No other policies or shared infrastructure touched.
