### PR TITLE
feat: add republish functionality and state management for trial publ…

### DIFF
--- a/robodojo/dispatch/executor.py
+++ b/robodojo/dispatch/executor.py
@@ -21,7 +21,7 @@ from robodojo.publish.webhook import notify_finish_webhook
 from robodojo.schemas import ArtifactPayload, DispatchPayload
 from robodojo.serialization import to_jsonable
 
-PublishSubmitFn = Callable[[Callable[[], Any]], Any]
+PublishSubmitFn = Callable[..., Any]
 
 
 def _resolved_artifact(dispatch: DispatchPayload) -> ArtifactPayload:
@@ -122,10 +122,46 @@ def _build_dispatch_summary(
     return summary
 
 
+def build_republish_work(
+    dispatch: DispatchPayload,
+    *,
+    evaluation_id: str,
+    trial_index: int,
+    hdf5_path: str,
+    run_status: str,
+    upload_s3: bool,
+    notify_webhook: bool,
+    webhook_secret: str | None,
+    error: dict[str, Any] | None = None,
+) -> Callable[[], tuple[dict[str, Any], str, dict[str, Any] | None]]:
+    trial_run = trial_run_for_index(
+        dispatch,
+        evaluation_id=evaluation_id,
+        trial_index=trial_index,
+    )
+
+    def do_publish() -> tuple[dict[str, Any], str, dict[str, Any] | None]:
+        return publish_pipeline.publish_trial_recording(
+            dispatch_for_trial(dispatch, trial_index),
+            finish_url=str(trial_run["finish_url"]),
+            run_status=run_status,
+            video_key=_trial_video_key(dispatch, trial_index),
+            hdf5_key=_trial_hdf5_key(dispatch, trial_index),
+            hdf5_path=hdf5_path,
+            error=error,
+            upload_s3=upload_s3,
+            notify_webhook=notify_webhook,
+            webhook_secret=webhook_secret,
+        )
+
+    return do_publish
+
+
 def _publish_after_trial(
     dispatch: DispatchPayload,
     run_dispatch_payload: DispatchPayload,
     *,
+    evaluation_id: str,
     trial_run: dict[str, object],
     trial_index: int,
     run_status: str,
@@ -156,7 +192,11 @@ def _publish_after_trial(
         )
 
     if publish_submit is not None:
-        publish_submit(do_publish)
+        publish_submit(
+            do_publish,
+            evaluation_id=evaluation_id,
+            trial_index=trial_index,
+        )
         if run_status == STATUS_DONE:
             return {"async": True}, STATUS_COMPLETED, error
         return {"async": True}, run_status, error
@@ -191,6 +231,7 @@ def _fail_dispatch(
         published, run_status, error = _publish_after_trial(
             dispatch,
             run_dispatch_payload,
+            evaluation_id=evaluation_id,
             trial_run=trial_run,
             trial_index=trial_index,
             run_status=run_status,
@@ -252,6 +293,7 @@ def _execute_dispatch(
         published, run_status, error = _publish_after_trial(
             dispatch,
             run_dispatch_payload,
+            evaluation_id=evaluation_id,
             trial_run=trial_run,
             trial_index=trial_index,
             run_status=run_status,

--- a/robodojo/publish/pipeline.py
+++ b/robodojo/publish/pipeline.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from robodojo.dispatch.errors import normalize_execution_error
 from robodojo.dispatch.status import STATUS_COMPLETED, STATUS_FAILED
+from robodojo.publish.state_store import PUBLISH_STATUS_DONE, PUBLISH_STATUS_FAILED
 from robodojo.publish.s3 import (
     UploadFileFn,
     resolve_artifact_payload,
@@ -158,6 +159,11 @@ def publish_trial_recording(
                 }
             except PUBLISH_ERRORS as webhook_exc:
                 published["webhook_error"] = str(webhook_exc)
+
+        publish_failed = bool(publish_error) or bool(published.get("webhook_error"))
+        published["publish_status"] = (
+            PUBLISH_STATUS_FAILED if publish_failed else PUBLISH_STATUS_DONE
+        )
 
         # The returned status mirrors the robot trial outcome, not the upload:
         # a failed upload never turns a successful trial into a failed one.

--- a/robodojo/publish/state_store.py
+++ b/robodojo/publish/state_store.py
@@ -1,0 +1,186 @@
+"""Persist dispatch and per-trial publish state under artifact_root."""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, unquote
+
+from robodojo.schemas import DispatchPayload
+
+PUBLISH_STATUS_PENDING = "pending"
+PUBLISH_STATUS_DONE = "done"
+PUBLISH_STATUS_FAILED = "failed"
+INCOMPLETE_STATUSES = frozenset({PUBLISH_STATUS_PENDING, PUBLISH_STATUS_FAILED})
+
+
+@dataclass(frozen=True)
+class PublishRecord:
+    evaluation_id: str
+    trial_index: int
+    hdf5_path: str | None
+    run_status: str
+    publish_status: str
+
+
+def _evaluation_dir(artifact_root: Path, evaluation_id: str) -> Path:
+    return Path(artifact_root) / quote(evaluation_id, safe="")
+
+
+def _dispatch_path(artifact_root: Path, evaluation_id: str) -> Path:
+    return _evaluation_dir(artifact_root, evaluation_id) / "dispatch.json"
+
+
+def _publish_path(artifact_root: Path, evaluation_id: str, trial_index: int) -> Path:
+    return (
+        _evaluation_dir(artifact_root, evaluation_id)
+        / "trials"
+        / str(trial_index)
+        / "publish.json"
+    )
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    data = json.dumps(payload, sort_keys=True).encode("utf-8")
+    with open(tmp, "wb") as fh:
+        fh.write(data)
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp, path)
+
+
+def record_dispatch(
+    artifact_root: Path,
+    evaluation_id: str,
+    dispatch: DispatchPayload,
+) -> None:
+    _atomic_write_json(
+        _dispatch_path(artifact_root, evaluation_id),
+        dispatch.model_dump(mode="json"),
+    )
+
+
+def load_dispatches(artifact_root: Path) -> dict[str, DispatchPayload]:
+    root = Path(artifact_root)
+    if not root.is_dir():
+        return {}
+
+    dispatches: dict[str, DispatchPayload] = {}
+    for eval_dir in root.iterdir():
+        if not eval_dir.is_dir():
+            continue
+        dispatch_file = eval_dir / "dispatch.json"
+        if not dispatch_file.is_file():
+            continue
+        try:
+            raw = json.loads(dispatch_file.read_text(encoding="utf-8"))
+            evaluation_id = unquote(eval_dir.name)
+            dispatches[evaluation_id] = DispatchPayload.model_validate(raw)
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+    return dispatches
+
+
+def record_pending(
+    artifact_root: Path,
+    evaluation_id: str,
+    trial_index: int,
+    hdf5_path: str | None,
+    run_status: str,
+) -> None:
+    path = _publish_path(artifact_root, evaluation_id, trial_index)
+    payload: dict[str, Any] = {
+        "evaluation_id": evaluation_id,
+        "trial_index": trial_index,
+        "hdf5_path": hdf5_path,
+        "run_status": run_status,
+        "publish_status": PUBLISH_STATUS_PENDING,
+    }
+    if path.is_file():
+        payload = {**json.loads(path.read_text(encoding="utf-8")), **payload}
+    _atomic_write_json(path, payload)
+
+
+def record_outcome(
+    artifact_root: Path,
+    evaluation_id: str,
+    trial_index: int,
+    publish_status: str,
+) -> None:
+    path = _publish_path(artifact_root, evaluation_id, trial_index)
+    payload: dict[str, Any] = {
+        "evaluation_id": evaluation_id,
+        "trial_index": trial_index,
+        "publish_status": publish_status,
+    }
+    if path.is_file():
+        payload = {**json.loads(path.read_text(encoding="utf-8")), **payload}
+    _atomic_write_json(path, payload)
+
+
+def load_publish_record(
+    artifact_root: Path,
+    evaluation_id: str,
+    trial_index: int,
+) -> PublishRecord | None:
+    path = _publish_path(artifact_root, evaluation_id, trial_index)
+    if not path.is_file():
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return PublishRecord(
+        evaluation_id=str(raw.get("evaluation_id", evaluation_id)),
+        trial_index=int(raw.get("trial_index", trial_index)),
+        hdf5_path=str(raw["hdf5_path"]) if raw.get("hdf5_path") else None,
+        run_status=str(raw.get("run_status", "done")),
+        publish_status=str(raw.get("publish_status", PUBLISH_STATUS_PENDING)),
+    )
+
+
+def load_incomplete(artifact_root: Path) -> list[PublishRecord]:
+    root = Path(artifact_root)
+    if not root.is_dir():
+        return []
+
+    records: list[PublishRecord] = []
+    for eval_dir in root.iterdir():
+        if not eval_dir.is_dir():
+            continue
+        evaluation_id = unquote(eval_dir.name)
+        trials_dir = eval_dir / "trials"
+        if not trials_dir.is_dir():
+            continue
+        for trial_dir in trials_dir.iterdir():
+            if not trial_dir.is_dir():
+                continue
+            publish_file = trial_dir / "publish.json"
+            if not publish_file.is_file():
+                continue
+            try:
+                trial_index = int(trial_dir.name)
+                raw = json.loads(publish_file.read_text(encoding="utf-8"))
+                publish_status = str(raw.get("publish_status", PUBLISH_STATUS_PENDING))
+                if publish_status not in INCOMPLETE_STATUSES:
+                    continue
+                records.append(
+                    PublishRecord(
+                        evaluation_id=str(raw.get("evaluation_id", evaluation_id)),
+                        trial_index=int(raw.get("trial_index", trial_index)),
+                        hdf5_path=str(raw["hdf5_path"])
+                        if raw.get("hdf5_path")
+                        else None,
+                        run_status=str(raw.get("run_status", "done")),
+                        publish_status=publish_status,
+                    )
+                )
+            except (OSError, json.JSONDecodeError, ValueError):
+                continue
+    records.sort(key=lambda item: (item.evaluation_id, item.trial_index))
+    return records

--- a/robodojo/servers/env_client_server.py
+++ b/robodojo/servers/env_client_server.py
@@ -18,8 +18,13 @@ from urllib.parse import quote, urlparse
 from pydantic import ValidationError
 
 from robodojo.dispatch.errors import normalize_execution_error
-from robodojo.dispatch.executor import run_dispatch
-from robodojo.env_client.api import EnvClientBaselineConfig, HealthResponse, TrialRunResponse
+from robodojo.dispatch.executor import build_republish_work, run_dispatch
+from robodojo.dispatch.status import STATUS_DONE, STATUS_FAILED
+from robodojo.env_client.api import (
+    EnvClientBaselineConfig,
+    HealthResponse,
+    TrialRunResponse,
+)
 from robodojo.env_client.runner import (
     DebugTrialRunner,
     TrialRunnerError,
@@ -29,6 +34,8 @@ from robodojo.env_client.runner import (
     reset_idle_env,
 )
 from robodojo.env_client.trial_control import StopRequestResult, TrialControlRegistry
+from robodojo.publish import state_store
+from robodojo.publish.state_store import PUBLISH_STATUS_FAILED
 from robodojo.schemas import DispatchPayload
 from robodojo.servers.preview_routes import (
     handle_preview_get,
@@ -70,10 +77,24 @@ class EnvClientServerState:
         compare=False,
     )
 
-    def submit_publish(self, work: Callable[[], Any]) -> Future[Any]:
+    def submit_publish(
+        self,
+        work: Callable[[], Any],
+        *,
+        evaluation_id: str,
+        trial_index: int,
+    ) -> Future[Any]:
         """Queue trial publishing on the background worker (fire-and-forget)."""
         future = self._publish_executor.submit(work)
         future.add_done_callback(_log_publish_failure)
+        future.add_done_callback(
+            lambda completed: _record_publish_outcome(
+                self.config.artifact_root,
+                evaluation_id,
+                trial_index,
+                completed,
+            )
+        )
         return future
 
     def shutdown_publish(self) -> None:
@@ -125,6 +146,82 @@ def _log_publish_failure(future: Future[Any]) -> None:
             + "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
             file=sys.stderr,
         )
+
+
+def _record_publish_outcome(
+    artifact_root: Path,
+    evaluation_id: str,
+    trial_index: int,
+    future: Future[Any],
+) -> None:
+    exc = future.exception()
+    if exc is not None:
+        state_store.record_outcome(
+            artifact_root,
+            evaluation_id,
+            trial_index,
+            PUBLISH_STATUS_FAILED,
+        )
+        return
+    try:
+        published, _, _ = future.result()
+        publish_status = str(published.get("publish_status", PUBLISH_STATUS_FAILED))
+        state_store.record_outcome(
+            artifact_root,
+            evaluation_id,
+            trial_index,
+            publish_status,
+        )
+    except Exception:  # noqa: BLE001 - best-effort persistence
+        state_store.record_outcome(
+            artifact_root,
+            evaluation_id,
+            trial_index,
+            PUBLISH_STATUS_FAILED,
+        )
+
+
+def _hdf5_path_from_summary(summary: dict[str, object]) -> str | None:
+    policy_result = _first_record(summary.get("policy_results"))
+    hdf5_path = policy_result.get("hdf5_path")
+    return str(hdf5_path) if hdf5_path else None
+
+
+def resume_incomplete_publishes(state: EnvClientServerState) -> int:
+    """Reload persisted dispatches and re-queue incomplete publish tasks."""
+    artifact_root = state.config.artifact_root
+    state.dispatches.update(state_store.load_dispatches(artifact_root))
+    queued = 0
+    for record in state_store.load_incomplete(artifact_root):
+        dispatch = state.dispatches.get(record.evaluation_id)
+        if dispatch is None:
+            continue
+        hdf5_path = record.hdf5_path
+        if not hdf5_path or not os.path.isfile(hdf5_path):
+            state_store.record_outcome(
+                artifact_root,
+                record.evaluation_id,
+                record.trial_index,
+                PUBLISH_STATUS_FAILED,
+            )
+            continue
+        work = build_republish_work(
+            dispatch,
+            evaluation_id=record.evaluation_id,
+            trial_index=record.trial_index,
+            hdf5_path=hdf5_path,
+            run_status=record.run_status,
+            upload_s3=state.config.upload_s3,
+            notify_webhook=state.config.notify_webhook,
+            webhook_secret=state.config.webhook_secret,
+        )
+        state.submit_publish(
+            work,
+            evaluation_id=record.evaluation_id,
+            trial_index=record.trial_index,
+        )
+        queued += 1
+    return queued
 
 
 def _first_record(items: object) -> dict[str, Any]:
@@ -206,7 +303,9 @@ def make_handler(state: EnvClientServerState) -> type[BaseHTTPRequestHandler]:
             if preview_route is not None:
                 action, role = preview_route
                 if action in ("pause", "resume"):
-                    self._write_json(HTTPStatus.NOT_FOUND, {"error": "unknown endpoint"})
+                    self._write_json(
+                        HTTPStatus.NOT_FOUND, {"error": "unknown endpoint"}
+                    )
                     return
                 handle_preview_get(self, state.preview, action, role)
                 return
@@ -229,7 +328,9 @@ def make_handler(state: EnvClientServerState) -> type[BaseHTTPRequestHandler]:
             if preview_route is not None:
                 action, _ = preview_route
                 if action not in ("pause", "resume"):
-                    self._write_json(HTTPStatus.NOT_FOUND, {"error": "unknown endpoint"})
+                    self._write_json(
+                        HTTPStatus.NOT_FOUND, {"error": "unknown endpoint"}
+                    )
                     return
                 handle_preview_post(self, state.preview, action)
                 return
@@ -253,6 +354,8 @@ def make_handler(state: EnvClientServerState) -> type[BaseHTTPRequestHandler]:
                     self._handle_start(evaluation_id, trial_index)
                 case "stop":
                     self._handle_stop(evaluation_id, trial_index)
+                case "republish":
+                    self._handle_republish(evaluation_id, trial_index)
 
         @property
         def _path(self) -> str:
@@ -276,6 +379,11 @@ def make_handler(state: EnvClientServerState) -> type[BaseHTTPRequestHandler]:
                 return
 
             state.dispatches[evaluation_id] = dispatch
+            state_store.record_dispatch(
+                state.config.artifact_root,
+                evaluation_id,
+                dispatch,
+            )
             self._write_json(
                 HTTPStatus.OK,
                 {
@@ -339,6 +447,16 @@ def make_handler(state: EnvClientServerState) -> type[BaseHTTPRequestHandler]:
             finally:
                 state.trial_control.clear(evaluation_id, trial_index)
 
+            if state.config.upload_s3 or state.config.notify_webhook:
+                run_status = STATUS_FAILED if exit_code != 0 else STATUS_DONE
+                state_store.record_pending(
+                    state.config.artifact_root,
+                    evaluation_id,
+                    trial_index,
+                    _hdf5_path_from_summary(summary),
+                    run_status,
+                )
+
             state.last_trial_id = _trial_id_from_summary(summary, trial_index)
             self._write_json(
                 HTTPStatus.OK,
@@ -355,6 +473,63 @@ def make_handler(state: EnvClientServerState) -> type[BaseHTTPRequestHandler]:
             result = state.trial_control.request_stop(evaluation_id, trial_index)
             status_code, body = _STOP_HTTP_RESPONSES[result]
             self._write_json(status_code, body)
+
+        def _handle_republish(self, evaluation_id: str, trial_index: int) -> None:
+            dispatch = state.dispatches.get(evaluation_id)
+            if dispatch is None:
+                self._write_json(
+                    HTTPStatus.NOT_FOUND,
+                    {"error": "dispatch payload not found"},
+                )
+                return
+
+            if not any(
+                trial.trial_index == trial_index
+                for trial in dispatch.evaluation_plan.trials
+            ):
+                self._write_json(
+                    HTTPStatus.NOT_FOUND,
+                    {"error": "trial not found in dispatch payload"},
+                )
+                return
+
+            publish_record = state_store.load_publish_record(
+                state.config.artifact_root,
+                evaluation_id,
+                trial_index,
+            )
+            hdf5_path = publish_record.hdf5_path if publish_record else None
+            if not hdf5_path or not os.path.isfile(hdf5_path):
+                self._write_json(
+                    HTTPStatus.CONFLICT,
+                    {"error": "recording no longer available for re-upload"},
+                )
+                return
+
+            run_status = publish_record.run_status if publish_record else STATUS_DONE
+            state_store.record_pending(
+                state.config.artifact_root,
+                evaluation_id,
+                trial_index,
+                hdf5_path,
+                run_status,
+            )
+            work = build_republish_work(
+                dispatch,
+                evaluation_id=evaluation_id,
+                trial_index=trial_index,
+                hdf5_path=hdf5_path,
+                run_status=run_status,
+                upload_s3=state.config.upload_s3,
+                notify_webhook=state.config.notify_webhook,
+                webhook_secret=state.config.webhook_secret,
+            )
+            state.submit_publish(
+                work,
+                evaluation_id=evaluation_id,
+                trial_index=trial_index,
+            )
+            self._write_json(HTTPStatus.OK, {"status": "republishing"})
 
         def _handle_reset(self) -> None:
             if state.trial_control.has_active_trials():
@@ -460,6 +635,10 @@ def session_start_path(evaluation_id: str, trial_index: int) -> str:
 
 def session_stop_path(evaluation_id: str, trial_index: int) -> str:
     return _session_path(evaluation_id, f"trials/{trial_index}/stop")
+
+
+def session_republish_path(evaluation_id: str, trial_index: int) -> str:
+    return _session_path(evaluation_id, f"trials/{trial_index}/republish")
 
 
 def add_debug_env_client_arguments(parser: argparse.ArgumentParser) -> None:
@@ -644,6 +823,12 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     server = create_server(args.serve_host, args.serve_port, state)
+    resumed = resume_incomplete_publishes(state)
+    if resumed:
+        print(
+            f"resumed {resumed} incomplete trial publish task(s) from artifact store",
+            file=sys.stderr,
+        )
     print(
         f"robodojo env client listening on http://{args.serve_host}:{args.serve_port}",
         file=sys.stderr,

--- a/robodojo/servers/session_routes.py
+++ b/robodojo/servers/session_routes.py
@@ -13,7 +13,7 @@ def parse_session_route(path: str) -> tuple[str, str, int | None] | None:
             return (evaluation_id, "dispatch", None) if evaluation_id else None
         case ["sessions", raw_evaluation_id, "trials", raw_trial_index, action]:
             evaluation_id = unquote(raw_evaluation_id)
-            if action not in ("start", "stop"):
+            if action not in ("start", "stop", "republish"):
                 return None
             try:
                 trial_index = int(raw_trial_index)

--- a/tests/test_robodojo_env_client_server.py
+++ b/tests/test_robodojo_env_client_server.py
@@ -619,7 +619,7 @@ def test_handle_start_submits_publish_in_background(tmp_path, monkeypatch):
             publish_release.wait(timeout=2)
             return {"webhook": {"status_code": 200}}, "completed", None
 
-        publish_submit(work)
+        publish_submit(work, evaluation_id="eval-1", trial_index=1)
         return 0, {
             "status": "completed",
             "policy_results": [{"trial_id": "case-1-r01", "steps": 1}],

--- a/tests/test_robodojo_eval_runner.py
+++ b/tests/test_robodojo_eval_runner.py
@@ -360,7 +360,7 @@ def test_run_dispatch_submits_publish_in_background(tmp_path, monkeypatch):
         fake_publish_trial_recording,
     )
 
-    def capture_submit(work):
+    def capture_submit(work, **_kwargs):
         submitted.append(work)
         return work()
 

--- a/tests/test_robodojo_publish_state_store.py
+++ b/tests/test_robodojo_publish_state_store.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from robodojo.dispatch.status import STATUS_DONE
+from robodojo.publish import state_store
+from robodojo.publish.state_store import (
+    PUBLISH_STATUS_DONE,
+    PUBLISH_STATUS_FAILED,
+    PUBLISH_STATUS_PENDING,
+)
+from robodojo.schemas import DispatchPayload
+from robodojo.servers.env_client_server import (
+    EnvClientServerState,
+    resume_incomplete_publishes,
+    session_republish_path,
+)
+from robodojo.servers.session_routes import parse_session_route
+from robodojo_fixtures import platform_dispatch
+from test_robodojo_env_client_server import (
+    _baseline,
+    _dispatch_payload,
+    _post,
+    _post_expect_http_error,
+    _running_server,
+    _server_config,
+    _start_trial,
+)
+
+
+def _dispatch_model() -> DispatchPayload:
+    return DispatchPayload.model_validate(_dispatch_payload())
+
+
+def test_state_store_round_trip(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    dispatch = _dispatch_model()
+    evaluation_id = "eval-abc"
+
+    state_store.record_dispatch(artifact_root, evaluation_id, dispatch)
+    state_store.record_pending(
+        artifact_root,
+        evaluation_id,
+        1,
+        "/tmp/trial.hdf5",
+        STATUS_DONE,
+    )
+
+    loaded = state_store.load_dispatches(artifact_root)
+    assert evaluation_id in loaded
+    assert loaded[evaluation_id].policy_server_url == dispatch.policy_server_url
+
+    record = state_store.load_publish_record(artifact_root, evaluation_id, 1)
+    assert record is not None
+    assert record.hdf5_path == "/tmp/trial.hdf5"
+    assert record.publish_status == PUBLISH_STATUS_PENDING
+
+    state_store.record_outcome(
+        artifact_root,
+        evaluation_id,
+        1,
+        PUBLISH_STATUS_DONE,
+    )
+    record = state_store.load_publish_record(artifact_root, evaluation_id, 1)
+    assert record is not None
+    assert record.publish_status == PUBLISH_STATUS_DONE
+    assert state_store.load_incomplete(artifact_root) == []
+
+
+def test_state_store_atomic_write(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    dispatch = _dispatch_model()
+    state_store.record_dispatch(artifact_root, "eval-1", dispatch)
+    dispatch_path = artifact_root / "eval-1" / "dispatch.json"
+    assert dispatch_path.is_file()
+    payload = json.loads(dispatch_path.read_text(encoding="utf-8"))
+    assert "evaluation_plan" in payload
+
+
+def test_parse_session_route_accepts_republish():
+    parsed = parse_session_route("/sessions/eval-1/trials/2/republish")
+    assert parsed == ("eval-1", "republish", 2)
+
+
+def test_resume_incomplete_publishes_queues_pending_tasks(tmp_path, monkeypatch):
+    artifact_root = tmp_path / "artifacts"
+    evaluation_id = "eval-resume"
+    hdf5_path = tmp_path / "recording.hdf5"
+    hdf5_path.write_bytes(b"hdf5")
+
+    state_store.record_dispatch(artifact_root, evaluation_id, _dispatch_model())
+    state_store.record_pending(
+        artifact_root,
+        evaluation_id,
+        1,
+        str(hdf5_path),
+        STATUS_DONE,
+    )
+
+    submitted: list[tuple[str, int]] = []
+
+    def capture_submit(work, *, evaluation_id, trial_index):
+        submitted.append((evaluation_id, trial_index))
+        return work()
+
+    state = EnvClientServerState(
+        baseline=_baseline(),
+        config=_server_config(tmp_path),
+    )
+
+    def capture_submit(work, *, evaluation_id, trial_index):
+        submitted.append((evaluation_id, trial_index))
+        return work()
+
+    state.submit_publish = capture_submit  # type: ignore[method-assign]
+
+    queued = resume_incomplete_publishes(state)
+    assert queued == 1
+    assert submitted == [(evaluation_id, 1)]
+    assert evaluation_id in state.dispatches
+
+
+def test_resume_incomplete_publishes_marks_missing_hdf5_failed(tmp_path):
+    artifact_root = tmp_path / "artifacts"
+    evaluation_id = "eval-missing"
+
+    state_store.record_dispatch(artifact_root, evaluation_id, _dispatch_model())
+    state_store.record_pending(
+        artifact_root,
+        evaluation_id,
+        1,
+        str(tmp_path / "missing.hdf5"),
+        STATUS_DONE,
+    )
+
+    state = EnvClientServerState(
+        baseline=_baseline(),
+        config=_server_config(tmp_path),
+    )
+    assert resume_incomplete_publishes(state) == 0
+    record = state_store.load_publish_record(artifact_root, evaluation_id, 1)
+    assert record is not None
+    assert record.publish_status == PUBLISH_STATUS_FAILED
+
+
+def test_handle_republish_returns_conflict_when_recording_missing(tmp_path):
+    with _running_server(
+        run_trial=lambda deploy_cfg: {
+            "status": "completed",
+            "trial_id": deploy_cfg["trial_id"],
+            "steps": 1,
+            "eval_env": "debug",
+            "policy_name": "demo_policy",
+        },
+        tmp_path=tmp_path,
+    ) as (server, _state):
+        port = server.server_address[1]
+        evaluation_id = "eval-republish-missing"
+        _post(port, f"/sessions/{evaluation_id}/dispatch", _dispatch_payload())
+        _post_expect_http_error(
+            port,
+            session_republish_path(evaluation_id, 1),
+            expected_code=409,
+        )
+
+
+def test_handle_republish_queues_publish_work(tmp_path, monkeypatch):
+    publish_started = threading.Event()
+    publish_release = threading.Event()
+    submitted: list[tuple[str, int]] = []
+
+    def fake_build_republish_work(*_args, **_kwargs):
+        def work():
+            publish_started.set()
+            publish_release.wait(timeout=2)
+            return {"publish_status": PUBLISH_STATUS_DONE}, "completed", None
+
+        return work
+
+    monkeypatch.setattr(
+        "robodojo.servers.env_client_server.build_republish_work",
+        fake_build_republish_work,
+    )
+
+    original_submit = EnvClientServerState.submit_publish
+
+    def capture_submit(self, work, *, evaluation_id, trial_index):
+        submitted.append((evaluation_id, trial_index))
+        return original_submit(self, work, evaluation_id=evaluation_id, trial_index=trial_index)
+
+    monkeypatch.setattr(EnvClientServerState, "submit_publish", capture_submit)
+
+    hdf5_path = tmp_path / "recording.hdf5"
+    hdf5_path.write_bytes(b"hdf5")
+
+    def fake_run_dispatch(*_args, **_kwargs):
+        return 0, {
+            "status": "completed",
+            "policy_results": [{"trial_id": "case-1-r01", "hdf5_path": str(hdf5_path)}],
+            "trial_runs": [{"trial_id": "case-1-r01"}],
+        }
+
+    monkeypatch.setattr(
+        "robodojo.servers.env_client_server.run_dispatch",
+        fake_run_dispatch,
+    )
+
+    with _running_server(
+        run_trial=lambda deploy_cfg: {
+            "status": "completed",
+            "trial_id": deploy_cfg["trial_id"],
+            "steps": 1,
+            "eval_env": "debug",
+            "policy_name": "demo_policy",
+        },
+        tmp_path=tmp_path,
+    ) as (server, state):
+        port = server.server_address[1]
+        evaluation_id = "eval-republish"
+        _start_trial(port, evaluation_id=evaluation_id, trial_index=1)
+        state_store.record_pending(
+            state.config.artifact_root,
+            evaluation_id,
+            1,
+            str(hdf5_path),
+            STATUS_DONE,
+        )
+
+        status, body = _post(
+            port,
+            session_republish_path(evaluation_id, 1),
+            {},
+        )
+        assert status == 200
+        assert body == {"status": "republishing"}
+        assert submitted == [(evaluation_id, 1)]
+        assert publish_started.wait(timeout=2)
+        publish_release.set()
+        state.shutdown_publish()
+
+        record = state_store.load_publish_record(
+            state.config.artifact_root,
+            evaluation_id,
+            1,
+        )
+        assert record is not None
+        assert record.publish_status == PUBLISH_STATUS_DONE


### PR DESCRIPTION
…ishing

- Introduced `build_republish_work` to facilitate republishing of trial recordings.
- Enhanced `_publish_after_trial` to include evaluation ID and trial index in publish submissions.
- Implemented state management for publish outcomes in `state_store`, including recording pending and completed statuses.
- Updated `EnvClientServerState` to handle republishing requests and resume incomplete publishes.
- Added tests for state store functionality and republish handling in session routes.