### PR TITLE
[XPolicyLab] update: improve policy data pipeline and eval robustness

### DIFF
--- a/policy/DP/README.md
+++ b/policy/DP/README.md
@@ -51,11 +51,10 @@ Parameters used by the command:
 | Parameter | Description |
 |---|---|
 | `bench_name` | Benchmark or dataset family, usually `RoboDojo`. |
-| `ckpt_name` | Data/run identifier. Use a different value for ablations, for example `stack_bowls_50ep`. |
+| `ckpt_name` | Data/run identifier. The script reads raw demos from `data/<bench_name>/<ckpt_name>/<env_cfg_type>`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
 | `action_type` | Action representation, for example `joint`. |
 | `expert_data_num` | Optional episode limit. Leave unset to use all episodes. |
-| `raw_task_dirs` | Optional source task directory or comma-separated task list when the script supports it. |
 
 ```bash
 cd XPolicyLab/policy/DP
@@ -65,8 +64,8 @@ bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type>
 # Example: convert stack_bowls demos for arx_x5 joint control.
 bash process_data.sh RoboDojo stack_bowls arx_x5 joint
 
-# Example: create a 50-episode ablation while reading from the original task data.
-bash process_data.sh RoboDojo stack_bowls_50ep arx_x5 joint 50 stack_bowls
+# Example: convert the first 50 episodes from data/RoboDojo/stack_bowls/arx_x5.
+bash process_data.sh RoboDojo stack_bowls arx_x5 joint 50
 ```
 
 ## Model Training
@@ -96,7 +95,7 @@ bash train.sh RoboDojo cotrain arx_x5 joint 0 0
 bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3
 ```
 
-The usual checkpoint directory is `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`. Pass that full directory name as `ckpt_name` during evaluation.
+Training saves checkpoints under `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`. Pass that full directory name as `ckpt_name` during evaluation.
 
 ## Deployment and Evaluation
 
@@ -209,6 +208,6 @@ Frequently used environment variables detected in the adapter scripts:
 
 ## Notes
 
-- Keep `ckpt_name` stable between data processing, training, and evaluation. For data-size ablations, encode the subset in `ckpt_name` such as `stack_bowls_50ep`.
+- Use the same short `ckpt_name` for data processing and training. During evaluation, pass the full checkpoint directory name, for example `RoboDojo-cotrain-arx_x5-joint-0`.
 - `task_name` is only the evaluation task; multi-task checkpoints can be evaluated on different tasks without renaming the checkpoint directory.
 - Prefer running `setup_eval_policy_server.sh` and `setup_eval_env_client.sh` separately when debugging dependency, CUDA, or model-loading issues.

--- a/policy/DP/model.py
+++ b/policy/DP/model.py
@@ -33,6 +33,7 @@ class Model(ModelTemplate):
         self.model = self.get_model(model_cfg=model_cfg)
 
         self.robot_action_dim_info = get_robot_action_dim_info(model_cfg['env_cfg_type'])
+        self._latest_env_idx_list = None
 
     def get_model(self, model_cfg):
         ckpt_setting = str(model_cfg['ckpt_name'])
@@ -90,13 +91,22 @@ class Model(ModelTemplate):
         env_idx_list = [obs["env_idx"] for obs in obs_list]
         obs_list = [encode_obs(obs, self.action_type, self.robot_action_dim_info) for obs in obs_list]
         self.runner.update_obs(obs_list, env_idx_list)
+        self._latest_env_idx_list = env_idx_list
 
     def get_action(self):
-        action_list = self.get_action_batch(env_idx_list=[0])
+        if not self._latest_env_idx_list:
+            raise RuntimeError("get_action() called before update_obs().")
+
+        action_list = self.get_action_batch(env_idx_list=[self._latest_env_idx_list[0]])
             
         return action_list[0]
 
-    def get_action_batch(self, env_idx_list):
+    def get_action_batch(self, env_idx_list=None):
+        if env_idx_list is None:
+            env_idx_list = self._latest_env_idx_list
+        if not env_idx_list:
+            raise RuntimeError("get_action_batch() called before update_obs_batch().")
+
         actions = self.runner.get_action(self.model, env_idx_list)
         action_dict_list = []
 
@@ -108,6 +118,7 @@ class Model(ModelTemplate):
 
     def reset(self):
         self.runner.reset_obs()
+        self._latest_env_idx_list = None
 
 def encode_obs(observation, action_type, robot_action_dim_info):
     head_img = (np.moveaxis(observation["vision"]["cam_head"]["color"], -1, 0) / 255)

--- a/policy/OpenVLA_OFT/README.md
+++ b/policy/OpenVLA_OFT/README.md
@@ -38,13 +38,42 @@ cd XPolicyLab/policy/OpenVLA_OFT
 bash install.sh
 # Example: activate the environment used later as <policy_conda_env>.
 conda activate <policy_env>  # e.g. openvla-oft
+
+# Download the base model to the default path used by train.sh and deploy.yml:
+# checkpoints/shared/openvla-7b
+cd openvla_oft
+python scripts/download_openvla.py
 ```
 
 ## Demo Data Processing
 
-What it does: prepares RoboDojo demonstration data for policy training. The output name should match the training run identity so `train.sh` can find it.
+What it does: prepares RoboDojo demonstration data for policy training. The TFDS dataset name must match the name used by `train.sh`.
 
-This adapter has no top-level `process_data.sh`. It expects data in the format consumed by the upstream project or by `deploy.yml`/environment variables. Use the upstream README under the vendored source tree when custom conversion is required.
+The default training run id is:
+
+```text
+<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>
+```
+
+`train.sh` looks for a TFDS dataset named `aloha_<run_id>` unless `OPENVLA_TFDS_DATASET_NAME` is set. Build the dataset with the same `<run_id>`:
+
+```bash
+# In XPolicyLab root, first convert RoboDojo/XPolicyLab HDF5 data to ALOHA layout.
+python scripts/transform_aloha_hdf5_format.py <xspark_data_dir> <aloha_output_dir>
+
+# Then build/register the TFDS dataset. The first argument should be the run id
+# without the leading "aloha_"; build_tfds_aloha.sh adds that prefix.
+cd policy/OpenVLA_OFT/openvla_oft
+TFDS_DATA_DIR="${PWD}/tensorflow_datasets" \
+  bash scripts/build_tfds_aloha.sh \
+    RoboDojo-cotrain-arx_x5-joint-0 \
+    <aloha_output_dir> \
+    <preprocessed_base_dir> \
+    0.05 \
+    0
+```
+
+If you use a custom TFDS name, set the same value for `OPENVLA_TFDS_DATASET_NAME` during training and set `tfds_dataset_name` or `unnorm_key` in `deploy.yml` for evaluation.
 
 ## Model Training
 
@@ -74,6 +103,16 @@ bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3
 ```
 
 The usual checkpoint directory is `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`. Pass that full directory name as `ckpt_name` during evaluation.
+
+By default, `train.sh` uses:
+
+| Input | Default |
+|---|---|
+| Base model | `checkpoints/shared/openvla-7b` |
+| TFDS root | `openvla_oft/tensorflow_datasets` |
+| TFDS dataset | `aloha_<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>` |
+
+Override these with `MODEL_DIR`, `DATA_ROOT`, and `OPENVLA_TFDS_DATASET_NAME` when needed.
 
 ## Deployment and Evaluation
 
@@ -148,6 +187,8 @@ bash setup_eval_env_client.sh \
 ```
 
 Set `EVAL_ENV_TYPE=debug` for offline shape/IO checks when the adapter supports it; leave it unset or set `EVAL_ENV_TYPE=sim` for RoboDojo simulation.
+
+`ckpt_name` should be the full run directory name under `checkpoints/`, a relative path under `policy/OpenVLA_OFT`, or an absolute path. The model loader now fails fast if the checkpoint root exists but no merged fine-tune weights are found, instead of silently evaluating the base model.
 
 ## Important Parameters
 

--- a/policy/OpenVLA_OFT/model.py
+++ b/policy/OpenVLA_OFT/model.py
@@ -199,7 +199,7 @@ def _resolve_finetune_dir(model_cfg: dict[str, Any]) -> Path | None:
 
     existing_roots: list[Path] = []
     for name in candidates:
-        checkpoint_root = (_CHECKPOINTS_DIR / name).expanduser().resolve()
+        checkpoint_root = _resolve_checkpoint_root(name)
         if not checkpoint_root.is_dir():
             continue
         existing_roots.append(checkpoint_root)
@@ -207,16 +207,18 @@ def _resolve_finetune_dir(model_cfg: dict[str, Any]) -> Path | None:
         if resolved is not None:
             return resolved
 
-    # No dir with real fine-tune weights (config.json). Preserve the existing
-    # fallback semantics (load base model) but make the degradation explicit.
     if existing_roots:
-        _LOGGER.warning(
-            "[OpenVLA_OFT] No fine-tune weights (%s) found under %s; "
-            "falling back to base model (has_finetune_weights=False).",
-            _WEIGHTS_MARKER,
-            existing_roots[0],
+        raise FileNotFoundError(
+            f"Found OpenVLA_OFT checkpoint root but no fine-tune weights ({_WEIGHTS_MARKER}) "
+            f"under: {existing_roots[0]}. Expected a merged checkpoint directory such as "
+            "`<run_id>--<step>_chkpt`."
         )
-        return existing_roots[0]
+    if candidates:
+        checked = [_resolve_checkpoint_root(name) for name in candidates]
+        raise FileNotFoundError(
+            "Could not find OpenVLA_OFT checkpoint. Pass the full run directory name "
+            f"under checkpoints/ or a valid path. Checked: {[str(path) for path in checked]}"
+        )
     return None
 
 
@@ -229,6 +231,15 @@ def _resolve_policy_path(value: str | None) -> Path | None:
     else:
         path = path.resolve()
     return path
+
+
+def _resolve_checkpoint_root(name: str) -> Path:
+    path = Path(name).expanduser()
+    if path.is_absolute():
+        return path.resolve()
+    if path.parent != Path("."):
+        return (_POLICY_DIR / path).resolve()
+    return (_CHECKPOINTS_DIR / path).resolve()
 
 
 def _resolve_checkpoint_path(model_cfg: dict[str, Any]) -> str:
@@ -249,12 +260,12 @@ def _resolve_checkpoint_path(model_cfg: dict[str, Any]) -> str:
 
     ckpt_setting = _build_ckpt_setting(model_cfg)
     if ckpt_setting:
-        checkpoint_root = (_CHECKPOINTS_DIR / ckpt_setting).expanduser().resolve()
+        checkpoint_root = _resolve_checkpoint_root(ckpt_setting)
         return str(checkpoint_root)
 
     ckpt_name = model_cfg.get("ckpt_name")
     if ckpt_name:
-        checkpoint_root = (_CHECKPOINTS_DIR / str(ckpt_name)).expanduser().resolve()
+        checkpoint_root = _resolve_checkpoint_root(str(ckpt_name))
         return str(checkpoint_root)
 
     if explicit_checkpoint:

--- a/policy/OpenVLA_OFT/openvla_oft/scripts/download_openvla.py
+++ b/policy/OpenVLA_OFT/openvla_oft/scripts/download_openvla.py
@@ -13,7 +13,7 @@ from huggingface_hub import snapshot_download
 
 
 DEFAULT_REPO_ID = "openvla/openvla-7b"
-DEFAULT_LOCAL_DIR = "models/openvla-7b"
+DEFAULT_LOCAL_DIR = Path(__file__).resolve().parents[2] / "checkpoints" / "shared" / "openvla-7b"
 
 
 def parse_args():
@@ -25,7 +25,7 @@ def parse_args():
     )
     parser.add_argument(
         "--local_dir",
-        default=DEFAULT_LOCAL_DIR,
+        default=str(DEFAULT_LOCAL_DIR),
         help="Directory to store the downloaded model snapshot.",
     )
     return parser.parse_args()

--- a/policy/OpenVLA_OFT/openvla_oft/scripts/finetune.sh
+++ b/policy/OpenVLA_OFT/openvla_oft/scripts/finetune.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${REPO_ROOT:-$(cd "${SCRIPT_DIR}/.." && pwd)}" # path to the openvla-oft repo
-MODEL_DIR="${MODEL_DIR:-/path/to/model_weights/openvla-7b}" # path to the pretrained OpenVLA model.
-DATA_ROOT="${DATA_ROOT:-/path/to/tensorflow_datasets}" # path to the TFDS datasets.
+POLICY_DIR="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+MODEL_DIR="${MODEL_DIR:-${POLICY_DIR}/checkpoints/shared/openvla-7b}" # path to the pretrained OpenVLA model.
+DATA_ROOT="${DATA_ROOT:-${REPO_ROOT}/tensorflow_datasets}" # path to the TFDS datasets.
 export HF_HOME="${HF_HOME:-${HOME}/.cache/huggingface}" # Hugging Face cache directory.
 export TRANSFORMERS_CACHE="${HF_HOME}/transformers"
 

--- a/policy/Pi_0/README.md
+++ b/policy/Pi_0/README.md
@@ -54,7 +54,7 @@ Parameters used by the command:
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
 | `action_type` | Action representation, for example `joint`. |
 | `expert_data_num` | Optional episode limit. Leave unset to use all episodes. |
-| `raw_task_dirs` | Optional source task directory or comma-separated task list when the script supports it. |
+| `raw_task_dirs` | Optional source task directory or comma-separated task list. Defaults to `ckpt_name`. |
 
 ```bash
 cd XPolicyLab/policy/Pi_0
@@ -66,7 +66,12 @@ bash process_data.sh RoboDojo stack_bowls arx_x5 joint
 
 # Example: create a 50-episode ablation while reading from the original task data.
 bash process_data.sh RoboDojo stack_bowls_50ep arx_x5 joint 50 stack_bowls
+
+# Example: merge multiple raw task dirs into one cotrain dataset.
+bash process_data.sh RoboDojo cotrain arx_x5 joint "" stack_bowls,push_T
 ```
+
+The output LeRobot repo id is `<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>`. `train.sh` uses the same repo id by default, so keep `ckpt_name`, `env_cfg_type`, and `action_type` aligned between processing and training.
 
 ## Model Training
 
@@ -96,6 +101,8 @@ bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3
 ```
 
 The usual checkpoint directory is `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`. Pass that full directory name as `ckpt_name` during evaluation.
+
+Before training, make sure normalization stats are available at `openpi/assets/RoboDojo_assets/arx_x5_sim/norm_stats.json`, or set `OPENPI_ROBODOJO_ASSETS_DIR` to a directory that contains `arx_x5_sim/norm_stats.json`. To train against an existing LeRobot repo instead of the default `<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>`, set `OPENPI_DATA_REPO_ID`.
 
 ## Deployment and Evaluation
 
@@ -210,7 +217,9 @@ Frequently used environment variables detected in the adapter scripts:
 | `JAX_COMPILATION_CACHE_DIR` | Optional override used by the local scripts or upstream runtime. |
 | `LOCAL_CACHE_ROOT` | Optional override used by the local scripts or upstream runtime. |
 | `OPENPI_DATA_MODE` | Optional override used by the local scripts or upstream runtime. |
+| `OPENPI_DATA_REPO_ID` | Overrides the LeRobot repo id used by `train.sh`; defaults to `<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>`. |
 | `OPENPI_LOCAL_CACHE_ROOT` | Optional override used by the local scripts or upstream runtime. |
+| `OPENPI_ROBODOJO_ASSETS_DIR` | Overrides the directory containing RoboDojo norm stats, for example a directory with `arx_x5_sim/norm_stats.json`. |
 | `OPENPI_ROOT` | Optional override used by the local scripts or upstream runtime. |
 | `OPENPI_SRC` | Optional override used by the local scripts or upstream runtime. |
 | `OPENPI_TRAIN_CONFIG_NAME` | Optional override used by the local scripts or upstream runtime. |

--- a/policy/Pi_0/openpi/scripts/process_data.py
+++ b/policy/Pi_0/openpi/scripts/process_data.py
@@ -114,6 +114,13 @@ def _make_action_from_state(state: np.ndarray) -> np.ndarray:
     action[-1] = state[-1]
     return action
 
+
+def _decode_instruction(instruction: Any) -> str:
+    if isinstance(instruction, (bytes, np.bytes_)):
+        return bytes(instruction).decode("utf-8")
+    return str(instruction)
+
+
 def load_data(ep_path) -> dict[str, Any]:
     with h5py.File(ep_path, "r") as ep:
         right_state = np.concatenate(
@@ -132,7 +139,7 @@ def load_data(ep_path) -> dict[str, Any]:
             if source_name in ep["vision"]:
                 images[output_name] = _load_compressed_images(ep["vision"][source_name], "colors")
         try:
-            instructions = ep["instructions"]
+            instructions = [_decode_instruction(instruction) for instruction in ep["instructions"][:]]
         except KeyError:
             instructions = None
 
@@ -172,6 +179,12 @@ def main():
         default="Do your job.",
         help="Default instruction when not present in HDF5",
     )
+    parser.add_argument(
+        "--raw-task-dirs",
+        type=str,
+        default=None,
+        help="Comma-separated raw task dirs under data/<bench_name>/; defaults to ckpt_name.",
+    )
     args = parser.parse_args()
 
     bench_name = args.bench_name
@@ -181,7 +194,11 @@ def main():
     repo_id = f"{bench_name}-{ckpt_name}-{env_cfg_type}-{action_type}"
     mode = args.mode
     instruction = args.instruction
-    load_data_dir = os.path.join(ROOT_PATH, "data", str(bench_name), str(ckpt_name), str(env_cfg_type))
+    raw_task_dirs = [
+        task_dir.strip()
+        for task_dir in (args.raw_task_dirs or ckpt_name).split(",")
+        if task_dir.strip()
+    ]
 
     env_cfg = load_yaml(os.path.join(ROOT_PATH, "./env_cfg", f"{env_cfg_type}.yml"))
     robot_type = env_cfg['config']['robot']
@@ -197,12 +214,23 @@ def main():
         robot_action_dim_info=robot_action_dim_info,
     )
 
-    episode_files = sorted(Path(load_data_dir).glob("data/episode_*.hdf5"))
-    if not episode_files:
-        episode_files = sorted(Path(load_data_dir).glob("*.hdf5"))
-    if args.expert_data_num is not None:
-        episode_files = episode_files[: args.expert_data_num]
-    for ep_file in tqdm(episode_files, desc="Processing episodes", unit="episode"):
+    episode_jobs = []
+    for raw_task_dir in raw_task_dirs:
+        load_data_dir = ROOT_PATH / "data" / str(bench_name) / raw_task_dir / str(env_cfg_type)
+        episode_files = sorted(load_data_dir.glob("data/episode_*.hdf5"))
+        if not episode_files:
+            episode_files = sorted(load_data_dir.glob("*.hdf5"))
+        if args.expert_data_num is not None:
+            episode_files = episode_files[: args.expert_data_num]
+        episode_jobs.extend((raw_task_dir, ep_file) for ep_file in episode_files)
+
+    if not episode_jobs:
+        raise FileNotFoundError(
+            "No HDF5 episodes found for raw task dirs "
+            f"{raw_task_dirs} under data/{bench_name}/<task>/{env_cfg_type}."
+        )
+
+    for raw_task_dir, ep_file in tqdm(episode_jobs, desc="Processing episodes", unit="episode"):
         try:
             data = load_data(ep_file)
             num_frames = data["state"].shape[0]
@@ -220,7 +248,7 @@ def main():
             
             dataset.save_episode()
             dataset.hf_dataset = dataset.create_hf_dataset()
-            tqdm.write(f"Finished {ep_file.name} with {num_frames} frames")
+            tqdm.write(f"Finished {raw_task_dir}/{ep_file.name} with {num_frames} frames")
         except Exception as e:
             tqdm.write(f"Error processing episode {ep_file}: {e}")
 

--- a/policy/Pi_0/openpi/src/openpi/training/config.py
+++ b/policy/Pi_0/openpi/src/openpi/training/config.py
@@ -5,6 +5,7 @@ from collections.abc import Sequence
 import dataclasses
 import difflib
 import logging
+import os
 import pathlib
 from typing import Any, Literal, Protocol, TypeAlias
 
@@ -30,7 +31,14 @@ import openpi.training.weight_loaders as weight_loaders
 import openpi.transforms as _transforms
 
 # RoboDojo normalization assets bundled with this adapter (openpi/assets/RoboDojo_assets).
-_ROBODOJO_ASSETS_DIR = pathlib.Path(__file__).resolve().parents[3] / "assets" / "RoboDojo_assets"
+_DEFAULT_ROBODOJO_ASSETS_DIR = pathlib.Path(__file__).resolve().parents[3] / "assets" / "RoboDojo_assets"
+_ROBODOJO_ASSETS_DIR = pathlib.Path(
+    os.environ.get("OPENPI_ROBODOJO_ASSETS_DIR", str(_DEFAULT_ROBODOJO_ASSETS_DIR))
+).expanduser()
+
+
+def _robodojo_repo_id(default: str = "RoboDojo_sim_arx-x5_v30") -> str:
+    return os.environ.get("OPENPI_DATA_REPO_ID", default)
 
 ModelType: TypeAlias = _model.ModelType
 # Work around a tyro issue with using nnx.filterlib.Filter directly.
@@ -573,7 +581,7 @@ _CONFIGS = [
         name="pi0_base_aloha_full_sim_arx-x5_seed_0",
         model=pi0_config.Pi0Config(),
         data=LeRobotAlohaDataConfig(
-            repo_id="RoboDojo_sim_arx-x5_v30",
+            repo_id=_robodojo_repo_id(),
             assets=AssetsConfig(
                 assets_dir=str(_ROBODOJO_ASSETS_DIR),
                 asset_id="arx_x5_sim",
@@ -608,7 +616,7 @@ _CONFIGS = [
         name="pi0_base_aloha_full_sim_arx-x5_seed_1",
         model=pi0_config.Pi0Config(),
         data=LeRobotAlohaDataConfig(
-            repo_id="RoboDojo_sim_arx-x5_v30",
+            repo_id=_robodojo_repo_id(),
             assets=AssetsConfig(
                 assets_dir=str(_ROBODOJO_ASSETS_DIR),
                 asset_id="arx_x5_sim",
@@ -643,7 +651,7 @@ _CONFIGS = [
         name="pi0_base_aloha_full_sim_arx-x5_seed_2",
         model=pi0_config.Pi0Config(),
         data=LeRobotAlohaDataConfig(
-            repo_id="RoboDojo_sim_arx-x5_v30",
+            repo_id=_robodojo_repo_id(),
             assets=AssetsConfig(
                 assets_dir=str(_ROBODOJO_ASSETS_DIR),
                 asset_id="arx_x5_sim",

--- a/policy/Pi_0/process_data.sh
+++ b/policy/Pi_0/process_data.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+if [[ $# -lt 4 ]]; then
+  echo "Usage: $0 <bench_name> <ckpt_name> <env_cfg_type> <action_type> [expert_data_num] [raw_task_dirs]" >&2
+  exit 1
+fi
+
 bench_name=$1
 ckpt_name=$2
 env_cfg_type=$3
 action_type=$4
 expert_data_num=${5:-}
+raw_task_dirs=${6:-}
 
 POLICY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mode="${OPENPI_DATA_MODE:-image}"
@@ -19,6 +25,9 @@ py_args=(
 )
 if [[ -n "${expert_data_num}" ]]; then
   py_args+=("${expert_data_num}")
+fi
+if [[ -n "${raw_task_dirs}" ]]; then
+  py_args+=(--raw-task-dirs "${raw_task_dirs}")
 fi
 
 cd "${POLICY_DIR}/openpi"

--- a/policy/Pi_0/train.sh
+++ b/policy/Pi_0/train.sh
@@ -18,9 +18,11 @@ POLICY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ckpt_setting="${bench_name}-${ckpt_name}-${env_cfg_type}-${action_type}-${seed}"
 ckpt_dir="${POLICY_DIR}/checkpoints/${ckpt_setting}"
 train_config_name="${OPENPI_TRAIN_CONFIG_NAME:-pi0_base_aloha_full_sim_arx-x5_seed_0}"
+data_repo_id="${OPENPI_DATA_REPO_ID:-${bench_name}-${ckpt_name}-${env_cfg_type}-${action_type}}"
 
 mkdir -p "${ckpt_dir}"
 export CUDA_VISIBLE_DEVICES="${gpu_id}"
+export OPENPI_DATA_REPO_ID="${data_repo_id}"
 
 # LeRobot loads parquet via HuggingFace datasets, which builds pyarrow mmap cache
 # under HF_DATASETS_CACHE. Keep dataset on shared storage, but use per-host local
@@ -31,6 +33,7 @@ export HF_DATASETS_CACHE="${LOCAL_CACHE_ROOT}/hf/datasets"
 export JAX_COMPILATION_CACHE_DIR="${LOCAL_CACHE_ROOT}/jax"
 
 echo "[Pi_0] train_config_name=${train_config_name}"
+echo "[Pi_0] data_repo_id=${OPENPI_DATA_REPO_ID}"
 echo "[Pi_0] local_cache_root=${LOCAL_CACHE_ROOT}"
 echo "[Pi_0] checkpoint_dir=${ckpt_dir}"
 

--- a/policy/Pi_05/README.md
+++ b/policy/Pi_05/README.md
@@ -53,8 +53,8 @@ Parameters used by the command:
 | `ckpt_name` | Data/run identifier. Use a different value for ablations, for example `stack_bowls_50ep`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
 | `action_type` | Action representation, for example `joint`. |
-| `expert_data_num` | Optional episode limit. Leave unset to use all episodes. |
-| `raw_task_dirs` | Optional source task directory or comma-separated task list when the script supports it. |
+| `expert_data_num` | Optional episode limit for data conversion only. It is not part of checkpoint naming. |
+| `raw_task_dirs` | Optional source task directory or comma-separated task list under `data/<bench_name>/`; defaults to `ckpt_name`. |
 
 ```bash
 cd XPolicyLab/policy/Pi_05
@@ -63,6 +63,9 @@ bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type>
 
 # Example: convert stack_bowls demos for arx_x5 joint control.
 bash process_data.sh RoboDojo stack_bowls arx_x5 joint
+
+# Example: write a differently named dataset while reading all stack_bowls demos.
+bash process_data.sh RoboDojo stack_bowls_ablation arx_x5 joint stack_bowls
 
 # Example: create a 50-episode ablation while reading from the original task data.
 bash process_data.sh RoboDojo stack_bowls_50ep arx_x5 joint 50 stack_bowls
@@ -81,7 +84,7 @@ Parameters used by the command:
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
 | `action_type` | Action representation, for example `joint`. |
 | `seed` | Random seed. |
-| `gpu_id` | GPU id or comma-separated GPU ids for the policy trainer. |
+| `gpu_id` | GPU id or comma-separated GPU ids for the policy trainer. `train.sh` sets `fsdp_devices=1` for one visible GPU and `2` for multi-GPU by default. |
 
 ```bash
 cd XPolicyLab/policy/Pi_05
@@ -96,6 +99,8 @@ bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3
 ```
 
 The usual checkpoint directory is `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`. Pass that full directory name as `ckpt_name` during evaluation.
+
+By default, training reads the LeRobot repo produced by `process_data.sh`: `<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>`. Override this with `OPENPI_LEROBOT_REPO_ID` when reusing an existing dataset.
 
 ## Deployment and Evaluation
 
@@ -185,7 +190,7 @@ Common parameter meanings used across the commands above:
 | `seed` | Evaluation seed. |
 | `policy_gpu_id` | GPU used by the policy server. |
 | `env_gpu_id` | GPU used by the RoboDojo simulation client. |
-| `policy_conda_env` | Conda environment for the policy server. |
+| `policy_uv_env` | `uv` to use `deploy.yml` `policy_uv_env_path`, or an explicit OpenPI project path for the policy server. |
 | `eval_env_conda_env` | Conda environment for RoboDojo simulation/client. |
 
 Policy-specific `deploy.yml` keys worth checking before evaluation:
@@ -210,6 +215,8 @@ Frequently used environment variables detected in the adapter scripts:
 | `JAX_COMPILATION_CACHE_DIR` | Optional override used by the local scripts or upstream runtime. |
 | `LOCAL_CACHE_ROOT` | Optional override used by the local scripts or upstream runtime. |
 | `OPENPI_DATA_MODE` | Optional override used by the local scripts or upstream runtime. |
+| `OPENPI_FSDP_DEVICES` | Overrides the FSDP device count passed to OpenPI training. |
+| `OPENPI_LEROBOT_REPO_ID` | Overrides the LeRobot repo id used by `train.sh`; defaults to `<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>`. |
 | `OPENPI_LOCAL_CACHE_ROOT` | Optional override used by the local scripts or upstream runtime. |
 | `OPENPI_ROOT` | Optional override used by the local scripts or upstream runtime. |
 | `OPENPI_SRC` | Optional override used by the local scripts or upstream runtime. |

--- a/policy/Pi_05/openpi/scripts/process_data.py
+++ b/policy/Pi_05/openpi/scripts/process_data.py
@@ -154,10 +154,17 @@ def main():
     parser.add_argument("action_type", type=str, help="Action type for artifact naming (e.g., joint)")
     parser.add_argument(
         "expert_data_num",
-        type=int,
+        type=str,
         nargs="?",
         default=None,
-        help="Optional number of episodes to process; defaults to all episodes.",
+        help="Optional number of episodes to process; non-numeric values are treated as raw_task_dirs.",
+    )
+    parser.add_argument(
+        "raw_task_dirs",
+        type=str,
+        nargs="?",
+        default=None,
+        help="Optional raw task dir or comma-separated dirs under data/<bench>/; defaults to ckpt_name.",
     )
     parser.add_argument(
         "--mode",
@@ -181,7 +188,16 @@ def main():
     repo_id = f"{bench_name}-{ckpt_name}-{env_cfg_type}-{action_type}"
     mode = args.mode
     instruction = args.instruction
-    load_data_dir = os.path.join(ROOT_PATH, "data", str(bench_name), str(ckpt_name), str(env_cfg_type))
+    expert_data_num = None
+    raw_task_dirs_arg = args.raw_task_dirs
+    if args.expert_data_num is not None:
+        try:
+            expert_data_num = int(args.expert_data_num)
+        except ValueError:
+            if args.raw_task_dirs is not None:
+                raise ValueError("raw_task_dirs was provided twice.") from None
+            raw_task_dirs_arg = args.expert_data_num
+    raw_task_dirs = [item.strip() for item in (raw_task_dirs_arg or ckpt_name).split(",") if item.strip()]
 
     env_cfg = load_yaml(os.path.join(ROOT_PATH, "./env_cfg", f"{env_cfg_type}.yml"))
     robot_type = env_cfg['config']['robot']
@@ -197,11 +213,15 @@ def main():
         robot_action_dim_info=robot_action_dim_info,
     )
 
-    episode_files = sorted(Path(load_data_dir).glob("data/episode_*.hdf5"))
-    if not episode_files:
-        episode_files = sorted(Path(load_data_dir).glob("*.hdf5"))
-    if args.expert_data_num is not None:
-        episode_files = episode_files[: args.expert_data_num]
+    episode_files = []
+    for raw_task_dir in raw_task_dirs:
+        load_data_dir = Path(ROOT_PATH) / "data" / str(bench_name) / raw_task_dir / str(env_cfg_type)
+        task_episode_files = sorted(load_data_dir.glob("data/episode_*.hdf5"))
+        if not task_episode_files:
+            task_episode_files = sorted(load_data_dir.glob("*.hdf5"))
+        episode_files.extend(task_episode_files)
+    if expert_data_num is not None:
+        episode_files = episode_files[:expert_data_num]
     for ep_file in tqdm(episode_files, desc="Processing episodes", unit="episode"):
         try:
             data = load_data(ep_file)

--- a/policy/Pi_05/process_data.sh
+++ b/policy/Pi_05/process_data.sh
@@ -5,7 +5,8 @@ bench_name=$1
 ckpt_name=$2
 env_cfg_type=$3
 action_type=$4
-expert_data_num=${5:-}
+expert_data_num_or_raw_task_dirs=${5:-}
+raw_task_dirs=${6:-}
 
 POLICY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 mode="${OPENPI_DATA_MODE:-image}"
@@ -17,8 +18,11 @@ py_args=(
   "${action_type}"
   --mode "${mode}"
 )
-if [[ -n "${expert_data_num}" ]]; then
-  py_args+=("${expert_data_num}")
+if [[ -n "${expert_data_num_or_raw_task_dirs}" ]]; then
+  py_args+=("${expert_data_num_or_raw_task_dirs}")
+fi
+if [[ -n "${raw_task_dirs}" ]]; then
+  py_args+=("${raw_task_dirs}")
 fi
 
 cd "${POLICY_DIR}/openpi"

--- a/policy/Pi_05/train.sh
+++ b/policy/Pi_05/train.sh
@@ -18,6 +18,9 @@ POLICY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ckpt_setting="${bench_name}-${ckpt_name}-${env_cfg_type}-${action_type}-${seed}"
 ckpt_dir="${POLICY_DIR}/checkpoints/${ckpt_setting}"
 train_config_name="${OPENPI_TRAIN_CONFIG_NAME:-pi05_base_aloha_full_sim_arx-x5_seed_0}"
+lerobot_repo_id="${OPENPI_LEROBOT_REPO_ID:-${bench_name}-${ckpt_name}-${env_cfg_type}-${action_type}}"
+gpu_count=$(awk -F',' '{print NF}' <<<"${gpu_id}")
+fsdp_devices="${OPENPI_FSDP_DEVICES:-$(( gpu_count < 2 ? 1 : 2 ))}"
 
 mkdir -p "${ckpt_dir}"
 export CUDA_VISIBLE_DEVICES="${gpu_id}"
@@ -31,6 +34,8 @@ export HF_DATASETS_CACHE="${LOCAL_CACHE_ROOT}/hf/datasets"
 export JAX_COMPILATION_CACHE_DIR="${LOCAL_CACHE_ROOT}/jax"
 
 echo "[Pi_05] train_config_name=${train_config_name}"
+echo "[Pi_05] lerobot_repo_id=${lerobot_repo_id}"
+echo "[Pi_05] fsdp_devices=${fsdp_devices}"
 echo "[Pi_05] local_cache_root=${LOCAL_CACHE_ROOT}"
 echo "[Pi_05] checkpoint_dir=${ckpt_dir}"
 
@@ -38,6 +43,8 @@ cd "${POLICY_DIR}/openpi/"
 XLA_PYTHON_CLIENT_MEM_FRACTION="${XLA_PYTHON_CLIENT_MEM_FRACTION:-0.9}" \
   uv run scripts/train.py "${train_config_name}" \
     --exp-name="${ckpt_setting}" \
+    --data.repo-id="${lerobot_repo_id}" \
+    --fsdp-devices="${fsdp_devices}" \
     --checkpoint-dir-override="${ckpt_dir}" \
     --seed="${seed}" \
     --overwrite

--- a/policy/RDT_1B/README.md
+++ b/policy/RDT_1B/README.md
@@ -34,14 +34,14 @@ Parameters used by the command:
 
 | Parameter | Description |
 |---|---|
-| `policy_env` | Name of the conda environment used by the policy runtime. |
+| `policy_env` | Name of the conda environment used by the policy runtime. `install.sh` defaults to `rdt_1b`; override it with `RDT_CONDA_ENV=<name>`. |
 
 ```bash
 cd XPolicyLab/policy/RDT_1B
 # Example: install dependencies for the RDT_1B policy adapter.
 bash install.sh
 # Example: activate the environment used later as <policy_conda_env>.
-conda activate <policy_env>  # e.g. rdt-1b
+conda activate <policy_env>  # e.g. rdt_1b
 ```
 
 ## Demo Data Processing

--- a/policy/RDT_1B/rdt/finetune.sh
+++ b/policy/RDT_1B/rdt/finetune.sh
@@ -16,7 +16,7 @@ export LDFLAGS="-L/usr/lib/x86_64-linux-gnu"
 export WANDB_PROJECT="robotics_diffusion_transformer"
 
 if [ ! -d "$OUTPUT_DIR" ]; then
-    mkdir - p "$OUTPUT_DIR"
+    mkdir -p "$OUTPUT_DIR"
     echo "Folder '$OUTPUT_DIR' created"
 else
     echo "Folder '$OUTPUT_DIR' already exists"

--- a/policy/SmolVLA/README.md
+++ b/policy/SmolVLA/README.md
@@ -16,7 +16,8 @@
 | `eval.sh` | Runs a same-machine policy server plus RoboDojo environment client evaluation. |
 | `setup_eval_policy_server.sh` | Starts only the policy server for distributed/debug evaluation. |
 | `setup_eval_env_client.sh` | Starts only the RoboDojo environment client and connects to a policy server. |
-| `deploy.py` | Policy wrapper used by the XPolicyLab model server. |
+| `deploy.sh` | Starts a standalone policy server from an explicit pretrained path. |
+| `deploy.py` | Evaluation helper functions for local/debug flows. |
 | `model.py` | Model adapter loaded by `deploy.py` or the policy server. |
 | `deploy.yml` | Runtime configuration and default checkpoint/model parameters. |
 
@@ -75,7 +76,9 @@ bash train.sh RoboDojo cotrain arx_x5 joint 0 0
 bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3
 ```
 
-The usual checkpoint directory is `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`. Pass that full directory name as `ckpt_name` during evaluation.
+The usual checkpoint directory is `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`. Pass that full directory name as `ckpt_name` during evaluation. For example, training with `bash train.sh RoboDojo cotrain arx_x5 joint 0 0` is evaluated with `ckpt_name=RoboDojo-cotrain-arx_x5-joint-0`.
+
+To evaluate a specific LeRobot training step, set `checkpoint_num` in `deploy.yml` or pass it as a server override. The adapter resolves step artifacts under `checkpoints/<run>/checkpoints/<step>/pretrained_model/`; if no `checkpoint_num` is provided, it prefers the latest numeric step when present and otherwise falls back to `checkpoints/<run>/checkpoints/last/pretrained_model/`.
 
 ## Deployment and Evaluation
 
@@ -173,7 +176,7 @@ Policy-specific `deploy.yml` keys worth checking before evaluation:
 | Key | Notes |
 |---|---|
 | `policy_name` | Runtime or checkpoint option consumed by this adapter. |
-| `env_cfg` | Runtime or checkpoint option consumed by this adapter. |
+| `env_cfg_type` | Robot/environment config used to pack RoboDojo observations and unpack actions. |
 | `checkpoint_num` | Runtime or checkpoint option consumed by this adapter. |
 | `result_dir` | Runtime or checkpoint option consumed by this adapter. |
 | `obs_transform_pipeline` | Runtime or checkpoint option consumed by this adapter. |
@@ -202,6 +205,6 @@ Frequently used environment variables detected in the adapter scripts:
 
 ## Notes
 
-- Keep `ckpt_name` stable between data processing, training, and evaluation. For data-size ablations, encode the subset in `ckpt_name` such as `stack_bowls_50ep`.
+- Keep the training `ckpt_name` stable when naming runs. During evaluation, pass the full checkpoint directory name under `checkpoints/`, such as `RoboDojo-stack_bowls_50ep-arx_x5-joint-0`.
 - `task_name` is only the evaluation task; multi-task checkpoints can be evaluated on different tasks without renaming the checkpoint directory.
 - Prefer running `setup_eval_policy_server.sh` and `setup_eval_env_client.sh` separately when debugging dependency, CUDA, or model-loading issues.

--- a/policy/SmolVLA/deploy.sh
+++ b/policy/SmolVLA/deploy.sh
@@ -7,6 +7,7 @@ policy_conda_env=${2}
 PRETRAINED_PATH=${3}
 PORT=${4:-6000}
 DEVICE=${5:-cuda}
+ENV_CFG_TYPE=${6:-${SMOVLA_ENV_CFG_TYPE:-arx_x5}}
 
 export CUDA_VISIBLE_DEVICES="${gpu_id}"
 echo -e "\033[33m[INFO] GPU ID (to use): ${gpu_id}\033[0m"
@@ -24,4 +25,6 @@ python "${ROOT_DIR}/XPolicyLab/setup_policy_server.py" \
         port="${PORT}" \
         policy_name="${policy_name}" \
         pretrained_path="${PRETRAINED_PATH}" \
-        device="${DEVICE}"
+        device="${DEVICE}" \
+        env_cfg_type="${ENV_CFG_TYPE}" \
+        action_type="joint"

--- a/policy/SmolVLA/model.py
+++ b/policy/SmolVLA/model.py
@@ -118,14 +118,32 @@ def _extract_step_number(value: Any) -> int | None:
 def _resolve_checkpoint_root(model_cfg: dict[str, Any]) -> Path | None:
     ckpt_name = model_cfg.get("ckpt_name")
     if ckpt_name:
-        direct_path = (_CHECKPOINTS_DIR / str(ckpt_name)).expanduser().resolve()
-        return direct_path
+        ckpt_path = Path(str(ckpt_name)).expanduser()
+        candidates = []
+        if ckpt_path.is_absolute():
+            candidates.append(ckpt_path)
+        else:
+            candidates.extend((_CHECKPOINTS_DIR / ckpt_path, _CUR_DIR / ckpt_path))
+
+        for candidate in candidates:
+            resolved = candidate.resolve()
+            if resolved.exists():
+                return resolved
+        return candidates[0].resolve()
 
     for key in ("pretrained_path", "model_path", "checkpoint_path"):
         value = model_cfg.get(key)
         if value:
             return Path(value).expanduser().resolve()
     return None
+
+
+def _has_lerobot_artifact(path: Path) -> bool:
+    return (
+        (path / "model.safetensors").is_file()
+        or (path / "pretrained_model" / "model.safetensors").is_file()
+        or (path / "checkpoints" / "last" / "pretrained_model" / "model.safetensors").is_file()
+    )
 
 def encode_obs(observation, action_type, robot_action_dim_info, default_prompt):
     if "images" in observation and "state" in observation:
@@ -206,14 +224,21 @@ class Model(ModelTemplate):
 
         artifact_root = checkpoint_root
         if checkpoint_root.is_dir():
-            candidate_dirs = []
-            if (checkpoint_root / "model.safetensors").exists() or (checkpoint_root / "pretrained_model").is_dir():
-                candidate_dirs.append(checkpoint_root)
-            candidate_dirs.extend(
-                child
-                for child in sorted(checkpoint_root.iterdir())
-                if child.is_dir() and ((child / "model.safetensors").exists() or (child / "pretrained_model").is_dir())
-            )
+            candidate_dirs: list[Path] = []
+
+            def add_candidate(candidate: Path):
+                if candidate.is_dir() and _has_lerobot_artifact(candidate) and candidate not in candidate_dirs:
+                    candidate_dirs.append(candidate)
+
+            add_candidate(checkpoint_root)
+            for child in sorted(checkpoint_root.iterdir()):
+                add_candidate(child)
+
+            lerobot_checkpoints = checkpoint_root / "checkpoints"
+            if lerobot_checkpoints.is_dir():
+                for child in sorted(lerobot_checkpoints.iterdir()):
+                    add_candidate(child)
+
             checkpoint_num = self.model_cfg.get("checkpoint_num")
             desired_step = _extract_step_number(checkpoint_num)
             if desired_step is not None:

--- a/policy/Spatial_Forcing/README.md
+++ b/policy/Spatial_Forcing/README.md
@@ -49,7 +49,7 @@ This adapter has no top-level `process_data.sh`. It expects data in the format c
 
 What it does: starts the policy-specific training recipe through the XPolicyLab wrapper and writes checkpoints under this adapter directory.
 
-No top-level `train.sh` is provided for this adapter. Train with the upstream project recipe, then point `deploy.yml`, `MODEL_PATH`, or the policy-specific checkpoint variable at the exported checkpoint.
+No top-level `train.sh` is provided for this adapter. Train with the upstream project recipe, then point `deploy.yml` `ckpt_name` at the exported checkpoint. The model adapter also accepts `model_path` or `checkpoint_path` when launching the policy server directly.
 
 ## Deployment and Evaluation
 
@@ -61,7 +61,7 @@ Parameters used by `eval.sh`:
 |---|---|
 | `bench_name` | Benchmark or dataset family, usually `RoboDojo`. |
 | `task_name` | RoboDojo simulation task to evaluate, for example `stack_bowls`. |
-| `ckpt_name` | Checkpoint/run directory name, usually under `checkpoints/`. |
+| `ckpt_name` | Checkpoint directory, absolute path, `checkpoints/...` path, or run name under this adapter's `checkpoints/`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
 | `action_type` | Action representation, for example `joint`. |
 | `seed` | Evaluation seed. |
@@ -85,7 +85,7 @@ Parameters used by the split server/client flow:
 |---|---|
 | `bench_name` | Benchmark or dataset family, usually `RoboDojo`. |
 | `task_name` | RoboDojo simulation task to evaluate, for example `stack_bowls`. |
-| `ckpt_name` | Checkpoint/run directory name, usually under `checkpoints/`. |
+| `ckpt_name` | Checkpoint directory, absolute path, `checkpoints/...` path, or run name under this adapter's `checkpoints/`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
 | `action_type` | Action representation, for example `joint`. |
 | `seed` | Evaluation seed. |
@@ -133,7 +133,7 @@ Common parameter meanings used across the commands above:
 |---|---|
 | `bench_name` | Benchmark or dataset family, usually `RoboDojo`. |
 | `task_name` | RoboDojo simulation task to evaluate, for example `stack_bowls`. |
-| `ckpt_name` | Checkpoint/run directory name, usually under `checkpoints/`. |
+| `ckpt_name` | Checkpoint directory, absolute path, `checkpoints/...` path, or run name under this adapter's `checkpoints/`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
 | `action_type` | Action representation, for example `joint`. |
 | `seed` | Evaluation seed. |

--- a/policy/Spatial_Forcing/setup_eval_env_client.sh
+++ b/policy/Spatial_Forcing/setup_eval_env_client.sh
@@ -29,6 +29,7 @@ find_xpolicylab_root() {
 XPL_ROOT="$(find_xpolicylab_root "${SCRIPT_DIR}")"
 BENCH_ROOT="$(cd "${XPL_ROOT}/.." && pwd)"
 UTILS_DIR="${XPL_ROOT}/utils"
+policy_name="$(basename "${SCRIPT_DIR}")"
 yaml_file="${XPL_ROOT}/policy/${policy_name}/deploy.yml"
 
 CONDA_BASE="$(conda info --base)"

--- a/policy/Spatial_Forcing/setup_eval_policy_server.sh
+++ b/policy/Spatial_Forcing/setup_eval_policy_server.sh
@@ -28,6 +28,7 @@ find_xpolicylab_root() {
 XPL_ROOT="$(find_xpolicylab_root "${SCRIPT_DIR}")"
 BENCH_ROOT="$(cd "${XPL_ROOT}/.." && pwd)"
 UTILS_DIR="${XPL_ROOT}/utils"
+policy_name="$(basename "${SCRIPT_DIR}")"
 yaml_file="${XPL_ROOT}/policy/${policy_name}/deploy.yml"
 
 CONDA_BASE="$(conda info --base)"

--- a/policy/Spirit_v15/INSTALLATION.md
+++ b/policy/Spirit_v15/INSTALLATION.md
@@ -44,5 +44,9 @@ pip install -e .
 | `XPOLICYLAB_DATA_ROOT` | XPolicyLab data root; conversion defaults to `../../../data`. |
 | `SPIRIT_CONVERTED_DATA_ROOT` | Converted Spirit training data directory. |
 | `SPIRIT_PATTERNS_CSV` | Data matching pattern, for example `RoboDojo.stack_bowls.arx_x5`. |
+| `SPIRIT_BACKBONE_PATH` | Optional local Qwen backbone directory used by upstream training. |
+| `HF_HOME` / `HF_HUB_CACHE` | Optional Hugging Face cache locations used when `spirit_backbone_path` points to a model id or cache-backed snapshot. |
 
 Run `process_data.sh` before `train.sh`; see `README.md` for the unified command interface.
+
+For evaluation, `deploy.yml` defaults to `checkpoints/shared/Spirit-v1.5` for the Spirit base config and `checkpoints/shared/Qwen3-VL-4B-Instruct` for the Qwen backbone. Put those local checkpoints there or override `spirit_base_weights` and `spirit_backbone_path` before starting the policy server.

--- a/policy/Spirit_v15/README.md
+++ b/policy/Spirit_v15/README.md
@@ -58,12 +58,12 @@ Parameters used by the command:
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
 | `action_type` | Action representation, for example `joint`. |
 | `expert_data_num` | Optional episode limit. Leave unset to use all episodes. |
-| `raw_task_dirs` | Optional source task directory or comma-separated task list when the script supports it. |
+| `raw_task_dirs` | Optional source task name or comma-separated task list. Use this when `ckpt_name` is only an output/run name, such as a data-size ablation. |
 
 ```bash
 cd XPolicyLab/policy/Spirit_v15
 # Template: convert all available demonstrations for one run.
-bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type>
+bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> [expert_data_num] [raw_task_dirs]
 
 # Example: convert stack_bowls demos for arx_x5 joint control.
 bash process_data.sh RoboDojo stack_bowls arx_x5 joint
@@ -100,6 +100,8 @@ bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3
 ```
 
 The usual checkpoint directory is `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`. Pass that full directory name as `ckpt_name` during evaluation.
+
+Spirit training writes `model.safetensors` into the run directory. The eval adapter also needs a compatible `config.json`; by default it links this from `checkpoints/shared/Spirit-v1.5/config.json` via `spirit_base_weights` in `deploy.yml`. Before evaluation, either place the Spirit base checkpoint there or override `spirit_base_weights`/`checkpoint_path` with a directory that already contains both `config.json` and `model.safetensors`.
 
 ## Deployment and Evaluation
 
@@ -200,7 +202,7 @@ Policy-specific `deploy.yml` keys worth checking before evaluation:
 | `checkpoint_num` | Runtime or checkpoint option consumed by this adapter. |
 | `policy_uv_env_path` | Runtime or checkpoint option consumed by this adapter. |
 | `spirit_base_weights` | Runtime or checkpoint option consumed by this adapter. |
-| `spirit_backbone_path` | Runtime or checkpoint option consumed by this adapter. |
+| `spirit_backbone_path` | Local Qwen backbone directory used for offline evaluation. Override this or set `HF_HOME`/`HF_HUB_CACHE` if the model is stored in a shared Hugging Face cache. |
 | `checkpoint_path` | Runtime or checkpoint option consumed by this adapter. |
 | `model_path` | Runtime or checkpoint option consumed by this adapter. |
 | `prompt` | Runtime or checkpoint option consumed by this adapter. |
@@ -229,5 +231,5 @@ Frequently used environment variables detected in the adapter scripts:
 ## Notes
 
 - Keep `ckpt_name` stable between data processing, training, and evaluation. For data-size ablations, encode the subset in `ckpt_name` such as `stack_bowls_50ep`.
-- `task_name` is only the evaluation task; multi-task checkpoints can be evaluated on different tasks without renaming the checkpoint directory.
+- `task_name` is the evaluation task. The adapter uses it when it exists in Spirit's task map, then falls back to `fallback_task_name` from `deploy.yml`.
 - Prefer running `setup_eval_policy_server.sh` and `setup_eval_env_client.sh` separately when debugging dependency, CUDA, or model-loading issues.

--- a/policy/Spirit_v15/deploy.yml
+++ b/policy/Spirit_v15/deploy.yml
@@ -20,7 +20,7 @@ checkpoint_path: null
 model_path: null
 prompt: null
 fallback_task_name: stack_bowls
-force_default_task_name: true
+force_default_task_name: false
 device: auto
 used_chunk_size: 60
 raw_embodiment_stats_json_path: null

--- a/policy/Spirit_v15/model.py
+++ b/policy/Spirit_v15/model.py
@@ -360,10 +360,17 @@ class Model(ModelTemplate):
 
         checkpoint_path = _resolve_spirit_checkpoint_dir(self.model_cfg)
         spirit_base_weights = _resolve_policy_path(self.model_cfg.get("spirit_base_weights"))
-        if spirit_base_weights and not (checkpoint_path / "config.json").exists():
-            base_config = spirit_base_weights / "config.json"
-            if base_config.exists():
+        if not checkpoint_path.is_dir():
+            raise FileNotFoundError(f"Spirit_v15 checkpoint directory not found: {checkpoint_path}")
+        if not (checkpoint_path / "config.json").exists():
+            base_config = spirit_base_weights / "config.json" if spirit_base_weights else None
+            if base_config and base_config.exists():
                 (checkpoint_path / "config.json").symlink_to(base_config)
+            else:
+                raise FileNotFoundError(
+                    "Spirit_v15 checkpoint is missing config.json and no usable "
+                    f"spirit_base_weights config was found: {spirit_base_weights}"
+                )
         checkpoint_path = str(checkpoint_path)
 
         self.default_task_name = None

--- a/policy/Spirit_v15/process_data.sh
+++ b/policy/Spirit_v15/process_data.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 if [[ $# -lt 4 ]]; then
-  echo "Usage: $0 <bench_name> <ckpt_name> <env_cfg_type> <action_type> [expert_data_num]" >&2
+  echo "Usage: $0 <bench_name> <ckpt_name> <env_cfg_type> <action_type> [expert_data_num] [raw_task_dirs]" >&2
   echo "  expert_data_num: optional; empty = use all episodes" >&2
+  echo "  raw_task_dirs: optional source task name or comma-separated task list" >&2
   exit 1
 fi
 
@@ -12,6 +13,7 @@ ckpt_name=$2
 env_cfg_type=$3
 action_type=$4
 expert_data_num=${5:-}
+raw_task_dirs=${6:-}
 
 POLICY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${POLICY_DIR}/../../.." && pwd)"
@@ -22,6 +24,27 @@ raw_data_root="${SPIRIT_RAW_DATA_ROOT:?set SPIRIT_RAW_DATA_ROOT to your RoboDojo
 resolve_patterns_csv() {
   if [[ -n "${SPIRIT_PATTERNS_CSV:-}" ]]; then
     echo "${SPIRIT_PATTERNS_CSV}"
+    return
+  fi
+  if [[ -n "${raw_task_dirs}" ]]; then
+    local source_bench="${bench_name}"
+    if [[ "${bench_name}" == "RoboDojo" && -d "${raw_data_root}/sim_cloud" ]]; then
+      source_bench="sim_cloud"
+    fi
+    local patterns=()
+    IFS=',' read -r -a task_names <<< "${raw_task_dirs}"
+    for task_name in "${task_names[@]}"; do
+      task_name="${task_name//[[:space:]]/}"
+      if [[ -n "${task_name}" ]]; then
+        patterns+=("${source_bench}.${task_name}.${env_cfg_type}")
+      fi
+    done
+    if [[ ${#patterns[@]} -eq 0 ]]; then
+      echo "raw_task_dirs did not contain any task names" >&2
+      exit 1
+    fi
+    local IFS=,
+    echo "${patterns[*]}"
     return
   fi
   if [[ "${ckpt_name}" == "cotrain" ]]; then
@@ -45,6 +68,7 @@ echo "[Spirit_v15] raw_data_root=${raw_data_root}"
 echo "[Spirit_v15] patterns_csv=${patterns_csv}"
 echo "[Spirit_v15] converted_data_root=${converted_data_root}"
 echo "[Spirit_v15] expert_data_num=${expert_data_num:-<all>}"
+echo "[Spirit_v15] raw_task_dirs=${raw_task_dirs:-<from ckpt_name>}"
 
 bash "${POLICY_DIR}/spirit_v15/scripts/train_xpolicylab_from_raw.sh" \
   "${raw_data_root}" \

--- a/policy/TinyVLA/README.md
+++ b/policy/TinyVLA/README.md
@@ -55,17 +55,20 @@ Parameters used by the command:
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
 | `action_type` | Action representation, for example `joint`. |
 | `expert_data_num` | Optional episode limit. Leave unset to use all episodes. |
-| `raw_task_dirs` | Optional source task directory or comma-separated task list when the script supports it. |
+| `raw_task_dirs` | Optional source task directory or comma-separated task list. Leave unset to convert all task directories under the source root. |
 
 ```bash
 cd XPolicyLab/policy/TinyVLA
 # Template: convert all available demonstrations for one run.
 bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type>
 
-# Example: convert stack_bowls demos for arx_x5 joint control.
-bash process_data.sh RoboDojo stack_bowls arx_x5 joint
+# Example: convert all RoboDojo demos for arx_x5 joint control.
+bash process_data.sh RoboDojo cotrain arx_x5 joint
 
-# Example: create a 50-episode ablation while reading from the original task data.
+# Example: convert only stack_bowls demos.
+bash process_data.sh RoboDojo stack_bowls arx_x5 joint stack_bowls
+
+# Example: create a 50-episode stack_bowls ablation.
 bash process_data.sh RoboDojo stack_bowls_50ep arx_x5 joint 50 stack_bowls
 ```
 

--- a/policy/TinyVLA/process_data.py
+++ b/policy/TinyVLA/process_data.py
@@ -40,6 +40,11 @@ def parse_args() -> argparse.Namespace:
                         help="Optional per-task episode cap; defaults to all episodes.")
     parser.add_argument("--source-root", type=Path, default=None)
     parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument(
+        "--tasks",
+        default=None,
+        help="Optional comma-separated task directory list; defaults to all tasks under source root.",
+    )
     parser.add_argument("--workers", type=int, default=min(8, os.cpu_count() or 1))
     parser.add_argument(
         "--compression",
@@ -225,9 +230,17 @@ def main() -> None:
     out_dir.mkdir(parents=True, exist_ok=False)
 
     robot_action_dim_info = get_robot_action_dim_info(args.env_cfg_type)
+    task_filter = None
+    if args.tasks:
+        task_filter = {task.strip() for task in args.tasks.split(",") if task.strip()}
+        if not task_filter:
+            raise ValueError("--tasks was provided but no valid task names were parsed.")
+
     episodes: list[tuple[str, Path]] = []
     for task_dir in sorted(path for path in root.iterdir() if path.is_dir()):
         task_name = task_dir.name
+        if task_filter is not None and task_name not in task_filter:
+            continue
         data_dir = task_dir / args.env_cfg_type / "data"
         episode_paths = sorted(data_dir.glob("episode_*.hdf5"))
         if args.expert_data_num is not None:
@@ -238,6 +251,14 @@ def main() -> None:
             f"[TinyVLA process_data] task='{task_name}': "
             f"queued {len(episode_paths)} episodes"
         )
+    if task_filter is not None:
+        found_tasks = {task_name for task_name, _ in episodes}
+        missing_tasks = sorted(task_filter - found_tasks)
+        if missing_tasks:
+            raise FileNotFoundError(
+                "Requested task(s) not found with episodes under source root: "
+                + ", ".join(missing_tasks)
+            )
     workers = args.workers
     jobs = [
         (

--- a/policy/TinyVLA/process_data.sh
+++ b/policy/TinyVLA/process_data.sh
@@ -2,8 +2,9 @@
 set -e
 
 
-if [[ $# -lt 4 || $# -gt 5 ]]; then
-  echo "Usage: bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> [expert_data_num]" >&2
+if [[ $# -lt 4 || $# -gt 6 ]]; then
+  echo "Usage: bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> [expert_data_num] [raw_task_dirs]" >&2
+  echo "       bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> [raw_task_dirs]" >&2
   exit 1
 fi
 
@@ -12,6 +13,12 @@ ckpt_name=${2}
 env_cfg_type=${3}
 action_type=${4}
 expert_data_num=${5:-}   # optional; empty = use all episodes
+raw_task_dirs=${6:-}      # optional comma-separated task directory list
+
+if [[ $# -eq 5 && -n "${expert_data_num}" && ! "${expert_data_num}" =~ ^[0-9]+$ ]]; then
+  raw_task_dirs="${expert_data_num}"
+  expert_data_num=""
+fi
 
 POLICY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${POLICY_DIR}/../../.." && pwd)"
@@ -25,6 +32,9 @@ out_dir="${POLICY_DIR}/data/${ckpt_setting}"
 echo "[TinyVLA process_data] output: ${out_dir}"
 echo "[TinyVLA process_data] source: ${SOURCE_ROOT}"
 echo "[TinyVLA process_data] workers=${WORKERS}, compression=${COMPRESSION}"
+if [[ -n "${raw_task_dirs}" ]]; then
+  echo "[TinyVLA process_data] tasks=${raw_task_dirs}"
+fi
 
 #If the 4-tuple output directory already exists, let the user decide:
 #   - y  : skip processing entirely, reuse the existing dataset as-is
@@ -44,13 +54,24 @@ if [[ -d "${out_dir}" ]]; then
   esac
 fi
 
-python "${POLICY_DIR}/process_data.py" \
-  "${bench_name}" \
-  "${ckpt_name}" \
-  "${env_cfg_type}" \
-  "${action_type}" \
-  ${expert_data_num:+"${expert_data_num}"} \
-  --source-root "${SOURCE_ROOT}" \
-  --output-dir "${out_dir}" \
-  --workers "${WORKERS}" \
+process_args=(
+  "${POLICY_DIR}/process_data.py"
+  "${bench_name}"
+  "${ckpt_name}"
+  "${env_cfg_type}"
+  "${action_type}"
+)
+if [[ -n "${expert_data_num}" ]]; then
+  process_args+=("${expert_data_num}")
+fi
+process_args+=(
+  --source-root "${SOURCE_ROOT}"
+  --output-dir "${out_dir}"
+  --workers "${WORKERS}"
   --compression "${COMPRESSION}"
+)
+if [[ -n "${raw_task_dirs}" ]]; then
+  process_args+=(--tasks "${raw_task_dirs}")
+fi
+
+python "${process_args[@]}"

--- a/policy/X_VLA/README.md
+++ b/policy/X_VLA/README.md
@@ -57,7 +57,7 @@ Parameters used by the command:
 | `bench_name` | Benchmark or dataset family, usually `RoboDojo`. |
 | `ckpt_name` | Training run identifier, for example `cotrain`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
-| `action_type` | Action representation, for example `joint`. |
+| `action_type` | Action representation. X_VLA currently supports only `ee`. |
 | `seed` | Random seed. |
 | `gpu_id` | GPU id or comma-separated GPU ids for the policy trainer. |
 
@@ -67,13 +67,13 @@ cd XPolicyLab/policy/X_VLA
 bash train.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> <seed> <gpu_id>
 
 # Example: train a cotrain run on GPU 0.
-bash train.sh RoboDojo cotrain arx_x5 joint 0 0
+bash train.sh RoboDojo cotrain arx_x5 ee 0 0
 
 # Example: train the same run on four GPUs if the upstream trainer supports it.
-bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3
+bash train.sh RoboDojo cotrain arx_x5 ee 0 0,1,2,3
 ```
 
-The usual checkpoint directory is `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`. Pass that full directory name as `ckpt_name` during evaluation.
+`train.sh` requires `XVLA_MODEL_PATH` to point to the pretrained X-VLA base model. Prefer a local directory so the script can copy processor/tokenizer files into each saved `ckpt-*` directory. The usual checkpoint directory is `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`; pass that full directory name as `ckpt_name` during evaluation.
 
 ## Deployment and Evaluation
 
@@ -87,7 +87,7 @@ Parameters used by `eval.sh`:
 | `task_name` | RoboDojo simulation task to evaluate, for example `stack_bowls`. |
 | `ckpt_name` | Checkpoint/run directory name, usually under `checkpoints/`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
-| `action_type` | Action representation, for example `joint`. |
+| `action_type` | Action representation. Must be `ee` for X_VLA. |
 | `seed` | Evaluation seed. |
 | `policy_gpu_id` | GPU used by the policy server. |
 | `env_gpu_id` | GPU used by the RoboDojo simulation client. |
@@ -100,7 +100,7 @@ cd XPolicyLab/policy/X_VLA
 bash eval.sh <bench_name> <task_name> <ckpt_name> <env_cfg_type> <action_type> <seed> <policy_gpu_id> <env_gpu_id> <policy_conda_env> <eval_env_conda_env>
 
 # Example: evaluate a trained cotrain checkpoint on stack_bowls.
-bash eval.sh RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-joint-0 arx_x5 joint 0 0 0 <policy_conda_env> <eval_env_conda_env>
+bash eval.sh RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-ee-0 arx_x5 ee 0 0 0 <policy_conda_env> <eval_env_conda_env>
 ```
 
 Parameters used by the split server/client flow:
@@ -111,7 +111,7 @@ Parameters used by the split server/client flow:
 | `task_name` | RoboDojo simulation task to evaluate, for example `stack_bowls`. |
 | `ckpt_name` | Checkpoint/run directory name, usually under `checkpoints/`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
-| `action_type` | Action representation, for example `joint`. |
+| `action_type` | Action representation. Must be `ee` for X_VLA. |
 | `seed` | Evaluation seed. |
 | `policy_gpu_id` | GPU used by the policy server. |
 | `env_gpu_id` | GPU used by the RoboDojo simulation client. |
@@ -120,7 +120,7 @@ Parameters used by the split server/client flow:
 | `policy_server_port` | Port exposed by the policy server, for example `5000`. |
 | `policy_server_host` | Server bind host, for example `0.0.0.0` on the policy machine. |
 | `policy_server_ip` | IP or hostname that the environment client uses to reach the policy server. |
-| `additional_info` | Comma-separated runtime overrides passed to the eval client, for example `ckpt_name=...,action_type=joint`. |
+| `additional_info` | Comma-separated runtime overrides passed to the eval client, for example `ckpt_name=...,action_type=ee`. |
 
 ```bash
 cd XPolicyLab/policy/X_VLA
@@ -131,7 +131,7 @@ bash setup_eval_policy_server.sh \
 
 # Example: bind the policy server to all interfaces on port 5000.
 bash setup_eval_policy_server.sh \
-  RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-joint-0 arx_x5 joint 0 \
+  RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-ee-0 arx_x5 ee 0 \
   0 <policy_conda_env> 5000 0.0.0.0
 
 # Terminal 2 on the environment machine: connect RoboDojo to the policy server.
@@ -142,8 +142,8 @@ bash setup_eval_env_client.sh \
 
 # Example: connect to a policy server reachable at <policy_server_ip>:5000.
 bash setup_eval_env_client.sh \
-  RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-joint-0 arx_x5 joint 0 \
-  0 <eval_env_conda_env> "ckpt_name=RoboDojo-cotrain-arx_x5-joint-0,action_type=joint" \
+  RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-ee-0 arx_x5 ee 0 \
+  0 <eval_env_conda_env> "ckpt_name=RoboDojo-cotrain-arx_x5-ee-0,action_type=ee" \
   5000 <policy_server_ip>
 ```
 
@@ -159,7 +159,7 @@ Common parameter meanings used across the commands above:
 | `task_name` | RoboDojo simulation task to evaluate, for example `stack_bowls`. |
 | `ckpt_name` | Checkpoint/run directory name, usually under `checkpoints/`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
-| `action_type` | Action representation, for example `joint`. |
+| `action_type` | Action representation. Must be `ee` for X_VLA. |
 | `seed` | Evaluation seed. |
 | `policy_gpu_id` | GPU used by the policy server. |
 | `env_gpu_id` | GPU used by the RoboDojo simulation client. |
@@ -171,12 +171,12 @@ Policy-specific `deploy.yml` keys worth checking before evaluation:
 | Key | Notes |
 |---|---|
 | `policy_name` | Runtime or checkpoint option consumed by this adapter. |
-| `env_cfg` | Runtime or checkpoint option consumed by this adapter. |
+| `env_cfg_type` | Robot/environment configuration consumed by this adapter. |
 | `checkpoint_num` | Runtime or checkpoint option consumed by this adapter. |
 | `obs_transform_pipeline` | Runtime or checkpoint option consumed by this adapter. |
 | `prompt` | Runtime or checkpoint option consumed by this adapter. |
 | `model_path` | Runtime or checkpoint option consumed by this adapter. |
-| `processor_path` | Runtime or checkpoint option consumed by this adapter. |
+| `processor_path` | Base model or checkpoint directory containing processor/tokenizer files. Defaults to `checkpoints/shared/X-VLA-Pt`; update it if your base model lives elsewhere. |
 | `lora_path` | Runtime or checkpoint option consumed by this adapter. |
 | `domain_id` | Runtime or checkpoint option consumed by this adapter. |
 | `steps` | Runtime or checkpoint option consumed by this adapter. |
@@ -194,13 +194,14 @@ Frequently used environment variables detected in the adapter scripts:
 | `XVLA` | Optional override used by the local scripts or upstream runtime. |
 | `XVLA_CONDA_ENV` | Optional override used by the local scripts or upstream runtime. |
 | `XVLA_META_PATH` | Optional override used by the local scripts or upstream runtime. |
-| `XVLA_MODEL_PATH` | Optional override used by the local scripts or upstream runtime. |
+| `XVLA_MODEL_PATH` | Required by `train.sh`; path or HF id for the pretrained X-VLA base model. Use a local directory when you want automatic processor/tokenizer copying into saved checkpoints. |
 | `XVLA_ROOT` | Optional override used by the local scripts or upstream runtime. |
 | `XVLA_SKIP_CONDA_CREATE` | Optional override used by the local scripts or upstream runtime. |
 | `X_VLA` | Optional override used by the local scripts or upstream runtime. |
 
 ## Notes
 
-- Keep `ckpt_name` stable between data processing, training, and evaluation. For data-size ablations, encode the subset in `ckpt_name` such as `stack_bowls_50ep`.
+- Keep `ckpt_name` stable between training and evaluation. For data-size ablations, encode the subset in `ckpt_name` such as `stack_bowls_50ep`.
+- If a checkpoint directory lacks processor/tokenizer files, set `processor_path` in `deploy.yml` to the base model directory before evaluation.
 - `task_name` is only the evaluation task; multi-task checkpoints can be evaluated on different tasks without renaming the checkpoint directory.
 - Prefer running `setup_eval_policy_server.sh` and `setup_eval_env_client.sh` separately when debugging dependency, CUDA, or model-loading issues.

--- a/policy/X_VLA/deploy.sh
+++ b/policy/X_VLA/deploy.sh
@@ -1,11 +1,16 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
-policy_name=XVLA
+if [[ $# -lt 3 ]]; then
+    echo "Usage: $0 <gpu_id> <policy_conda_env> <model_path> [processor_path] [port] [device]" >&2
+    exit 1
+fi
+
+policy_name=X_VLA
 gpu_id=${1}
 policy_conda_env=${2}
 MODEL_PATH=${3}
-PROCESSOR_PATH=${4}
+PROCESSOR_PATH=${4:-${MODEL_PATH}}
 PORT=${5:-6000}
 DEVICE=${6:-cuda}
 
@@ -13,7 +18,7 @@ export CUDA_VISIBLE_DEVICES="${gpu_id}"
 echo -e "\033[33m[INFO] GPU ID (to use): ${gpu_id}\033[0m"
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
-yaml_file="${ROOT_DIR}/XPolicyLab/policy/X-VLA/deploy.yml"
+yaml_file="${ROOT_DIR}/XPolicyLab/policy/X_VLA/deploy.yml"
 
 source "$(conda info --base)/etc/profile.d/conda.sh"
 conda activate "${policy_conda_env}"

--- a/policy/X_WAM/README.md
+++ b/policy/X_WAM/README.md
@@ -52,8 +52,8 @@ Parameters used by the command:
 | `bench_name` | Benchmark or dataset family, usually `RoboDojo`. |
 | `ckpt_name` | Data/run identifier. Use a different value for ablations, for example `stack_bowls_50ep`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
-| `action_type` | Action representation, for example `joint`. |
-| `expert_data_num` | Optional episode limit. Leave unset to use all episodes. |
+| `action_type` | Action representation. X-WAM only supports `ee`. |
+| `limit` | Optional episode limit. Leave unset to use all episodes. |
 | `raw_task_dirs` | Optional source task directory or comma-separated task list when the script supports it. |
 
 ```bash
@@ -61,11 +61,11 @@ cd XPolicyLab/policy/X_WAM
 # Template: convert all available demonstrations for one run.
 bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type>
 
-# Example: convert stack_bowls demos for arx_x5 joint control.
-bash process_data.sh RoboDojo stack_bowls arx_x5 joint
+# Example: convert stack_bowls demos for arx_x5 EE control.
+bash process_data.sh RoboDojo stack_bowls arx_x5 ee
 
 # Example: create a 50-episode ablation while reading from the original task data.
-bash process_data.sh RoboDojo stack_bowls_50ep arx_x5 joint 50 stack_bowls
+bash process_data.sh RoboDojo stack_bowls_50ep arx_x5 ee 50 stack_bowls
 ```
 
 ## Model Training
@@ -79,7 +79,7 @@ Parameters used by the command:
 | `bench_name` | Benchmark or dataset family, usually `RoboDojo`. |
 | `ckpt_name` | Training run identifier, for example `cotrain`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
-| `action_type` | Action representation, for example `joint`. |
+| `action_type` | Action representation. X-WAM only supports `ee`. |
 | `seed` | Random seed. |
 | `gpu_id` | GPU id or comma-separated GPU ids for the policy trainer. |
 | `num_gpus` | Optional explicit process count; inferred from comma-separated `gpu_id` when omitted. |
@@ -89,11 +89,11 @@ cd XPolicyLab/policy/X_WAM
 # Template: train a policy run on one GPU or a GPU list.
 bash train.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> <seed> <gpu_id>
 
-# Example: train a cotrain run on GPU 0.
-bash train.sh RoboDojo cotrain arx_x5 joint 0 0
+# Example: train a cotrain run on GPU 0 using stack_bowls raw demonstrations if converted data is missing.
+XWAM_RAW_TASK_DIRS=stack_bowls bash train.sh RoboDojo cotrain arx_x5 ee 0 0
 
 # Example: train the same run on four GPUs if the upstream trainer supports it.
-bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3
+XWAM_RAW_TASK_DIRS=stack_bowls bash train.sh RoboDojo cotrain arx_x5 ee 0 0,1,2,3
 ```
 
 The usual checkpoint directory is `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`. Pass that full directory name as `ckpt_name` during evaluation.
@@ -110,7 +110,7 @@ Parameters used by `eval.sh`:
 | `task_name` | RoboDojo simulation task to evaluate, for example `stack_bowls`. |
 | `ckpt_name` | Checkpoint/run directory name, usually under `checkpoints/`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
-| `action_type` | Action representation, for example `joint`. |
+| `action_type` | Action representation. X-WAM only supports `ee`. |
 | `seed` | Evaluation seed. |
 | `policy_gpu_id` | GPU used by the policy server. |
 | `env_gpu_id` | GPU used by the RoboDojo simulation client. |
@@ -123,7 +123,7 @@ cd XPolicyLab/policy/X_WAM
 bash eval.sh <bench_name> <task_name> <ckpt_name> <env_cfg_type> <action_type> <seed> <policy_gpu_id> <env_gpu_id> <policy_conda_env> <eval_env_conda_env>
 
 # Example: evaluate a trained cotrain checkpoint on stack_bowls.
-bash eval.sh RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-joint-0 arx_x5 joint 0 0 0 <policy_conda_env> <eval_env_conda_env>
+bash eval.sh RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-ee-0 arx_x5 ee 0 0 0 <policy_conda_env> <eval_env_conda_env>
 ```
 
 Parameters used by the split server/client flow:
@@ -134,7 +134,7 @@ Parameters used by the split server/client flow:
 | `task_name` | RoboDojo simulation task to evaluate, for example `stack_bowls`. |
 | `ckpt_name` | Checkpoint/run directory name, usually under `checkpoints/`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
-| `action_type` | Action representation, for example `joint`. |
+| `action_type` | Action representation. X-WAM only supports `ee`. |
 | `seed` | Evaluation seed. |
 | `policy_gpu_id` | GPU used by the policy server. |
 | `env_gpu_id` | GPU used by the RoboDojo simulation client. |
@@ -143,7 +143,7 @@ Parameters used by the split server/client flow:
 | `policy_server_port` | Port exposed by the policy server, for example `5000`. |
 | `policy_server_host` | Server bind host, for example `0.0.0.0` on the policy machine. |
 | `policy_server_ip` | IP or hostname that the environment client uses to reach the policy server. |
-| `additional_info` | Comma-separated runtime overrides passed to the eval client, for example `ckpt_name=...,action_type=joint`. |
+| `additional_info` | Comma-separated runtime overrides passed to the eval client, for example `ckpt_name=...,action_type=ee`. |
 
 ```bash
 cd XPolicyLab/policy/X_WAM
@@ -154,7 +154,7 @@ bash setup_eval_policy_server.sh \
 
 # Example: bind the policy server to all interfaces on port 5000.
 bash setup_eval_policy_server.sh \
-  RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-joint-0 arx_x5 joint 0 \
+  RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-ee-0 arx_x5 ee 0 \
   0 <policy_conda_env> 5000 0.0.0.0
 
 # Terminal 2 on the environment machine: connect RoboDojo to the policy server.
@@ -165,8 +165,8 @@ bash setup_eval_env_client.sh \
 
 # Example: connect to a policy server reachable at <policy_server_ip>:5000.
 bash setup_eval_env_client.sh \
-  RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-joint-0 arx_x5 joint 0 \
-  0 <eval_env_conda_env> "ckpt_name=RoboDojo-cotrain-arx_x5-joint-0,action_type=joint" \
+  RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-ee-0 arx_x5 ee 0 \
+  0 <eval_env_conda_env> "ckpt_name=RoboDojo-cotrain-arx_x5-ee-0,action_type=ee" \
   5000 <policy_server_ip>
 ```
 
@@ -182,7 +182,7 @@ Common parameter meanings used across the commands above:
 | `task_name` | RoboDojo simulation task to evaluate, for example `stack_bowls`. |
 | `ckpt_name` | Checkpoint/run directory name, usually under `checkpoints/`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
-| `action_type` | Action representation, for example `joint`. |
+| `action_type` | Action representation. X-WAM only supports `ee`. |
 | `seed` | Evaluation seed. |
 | `policy_gpu_id` | GPU used by the policy server. |
 | `env_gpu_id` | GPU used by the RoboDojo simulation client. |
@@ -206,22 +206,24 @@ Policy-specific `deploy.yml` keys worth checking before evaluation:
 | `cfg` | Runtime or checkpoint option consumed by this adapter. |
 | `replan_steps` | Runtime or checkpoint option consumed by this adapter. |
 
-Frequently used environment variables detected in the adapter scripts:
+Frequently used environment variables:
 
 | Variable | Notes |
 |---|---|
-| `CLEANUP` | Optional override used by the local scripts or upstream runtime. |
-| `CUDA` | Optional override used by the local scripts or upstream runtime. |
-| `EVAL_DIR` | Optional override used by the local scripts or upstream runtime. |
-| `EVAL_ENV_TYPE` | Optional override used by the local scripts or upstream runtime. |
-| `HDF5` | Optional override used by the local scripts or upstream runtime. |
-| `IMREAD_COLOR` | Optional override used by the local scripts or upstream runtime. |
-| `JPEG` | Optional override used by the local scripts or upstream runtime. |
-| `POLICY_DIR` | Optional override used by the local scripts or upstream runtime. |
-| `PYTHONUNBUFFERED` | Optional override used by the local scripts or upstream runtime. |
-| `PYTHONWARNINGS` | Optional override used by the local scripts or upstream runtime. |
-| `TASK_ENV` | Optional override used by the local scripts or upstream runtime. |
-| `TI2V` | Optional override used by the local scripts or upstream runtime. |
+| `XWAM_RAW_DATA_ROOT` | Root containing raw benchmark directories; defaults to `<repo>/final_data`. |
+| `XWAM_RAW_INPUT_DIR` | Direct raw input root containing `<task>/<env_cfg_type>/data/*.hdf5`; bypasses staging. |
+| `XWAM_RAW_TASK_DIRS` | Comma-separated raw task dirs used by `train.sh` auto-conversion when data is missing. |
+| `XWAM_DATASET_PATH` | Converted dataset directory used by `process_data.sh` and `train.sh`. |
+| `XWAM_DATA_LIMIT` | Optional episode limit used by `train.sh` auto-conversion. |
+| `XWAM_TRANSFORM_WORKERS` | Worker count for `transform_robodojo_to_xwam.py`; defaults to `16`. |
+| `XWAM_WAN_CHECKPOINT_DIR` | Wan2.2-TI2V-5B base weight directory. |
+| `XWAM_PRETRAINED_CHECKPOINT` | Optional pretrained X-WAM checkpoint for training initialization. |
+| `XWAM_EXP_PATH` | Evaluation experiment directory containing `config.yaml` and `checkpoints/`. |
+| `XWAM_CKPT_ROOT` | Evaluation checkpoint root used with `XWAM_EXP_SETTING` when `XWAM_EXP_PATH` is unset. |
+| `XWAM_EXP_SETTING` | Evaluation experiment directory name; defaults to the eval `ckpt_name`. |
+| `XWAM_STEPS` | Evaluation checkpoint step; defaults to `last`. |
+| `XWAM_ALLOW_DUMMY_POLICY` | Set to `true` to skip checkpoint loading for protocol debugging. |
+| `EVAL_ENV_TYPE` | Evaluation client mode: unset/`sim`, `debug`, or `real`. |
 
 ## Notes
 

--- a/policy/X_WAM/process_data.sh
+++ b/policy/X_WAM/process_data.sh
@@ -12,12 +12,12 @@ set -euo pipefail
 #
 # Usage:
 #   bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> \
-#       [expert_data_num] [raw_task_dirs]
+#       [limit] [raw_task_dirs]
 #
-# expert_data_num : optional; empty = convert all episodes. Maps to the
-#                   transform's global --limit (applied across the staged tasks).
-# raw_task_dirs   : comma-separated raw task dir name(s) under the raw bench root;
-#                   defaults to <ckpt_name>. Multiple tasks merge into one dataset.
+# limit         : optional; empty = convert all episodes. Maps to the transform's
+#                 global --limit (applied across the staged tasks).
+# raw_task_dirs : comma-separated raw task dir name(s) under the raw bench root;
+#                 defaults to <ckpt_name>. Multiple tasks merge into one dataset.
 #
 # Raw data location (no personal paths are hard-coded):
 #   XWAM_RAW_INPUT_DIR : if set, used directly as the transform --input-dir
@@ -26,12 +26,12 @@ set -euo pipefail
 #                        ${XWAM_RAW_DATA_ROOT}/<bench_name>. Default:
 #                        ${ROOT_DIR}/final_data.
 #   XWAM_DATASET_PATH  : override the converted-dataset output dir.
-bench_name=${1:?Usage: bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> [expert_data_num] [raw_task_dirs]}
+bench_name=${1:?Usage: bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> [limit] [raw_task_dirs]}
 ckpt_name=${2:?}
 env_cfg_type=${3:?}
 action_type=${4:?}
-expert_data_num=${5:-}
-raw_task_dirs=${6:-${ckpt_name}}
+limit=${5:-${XWAM_DATA_LIMIT:-}}
+raw_task_dirs=${6:-${XWAM_RAW_TASK_DIRS:-${ckpt_name}}}
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
@@ -83,9 +83,10 @@ transform_args=(
     --input-dir "${input_dir}"
     --output-dir "${output_dir}"
     --workers "${workers}"
+    --env-cfg-type "${env_cfg_type}"
 )
-if [[ -n "${expert_data_num}" ]]; then
-    transform_args+=(--limit "${expert_data_num}")
+if [[ -n "${limit}" ]]; then
+    transform_args+=(--limit "${limit}")
 fi
 
 python "${POLICY_DIR}/transform_robodojo_to_xwam.py" "${transform_args[@]}"

--- a/policy/X_WAM/train.sh
+++ b/policy/X_WAM/train.sh
@@ -55,11 +55,14 @@ data_key="${bench_name}-${ckpt_name}-${env_cfg_type}-${action_type}"
 # XWAM_DATASET_PATH env resolver referenced by configs/data/robodojo.yaml.
 dataset_path="${XWAM_DATASET_PATH:-${POLICY_DIR}/data/${data_key}}"
 exp_root="${POLICY_DIR}/checkpoints"
+raw_task_dirs="${XWAM_RAW_TASK_DIRS:-${ckpt_name}}"
+data_limit="${XWAM_DATA_LIMIT:-}"
 
 if [[ ! -d "${dataset_path}/data" ]]; then
     echo "[X_WAM] Converted dataset not found at ${dataset_path}; running process_data.sh first."
+    echo "[X_WAM] Auto-converting raw_task_dirs=${raw_task_dirs}, limit=${data_limit:-all}."
     XWAM_DATASET_PATH="${dataset_path}" bash "${POLICY_DIR}/process_data.sh" \
-        "${bench_name}" "${ckpt_name}" "${env_cfg_type}" "${action_type}"
+        "${bench_name}" "${ckpt_name}" "${env_cfg_type}" "${action_type}" "${data_limit}" "${raw_task_dirs}"
 fi
 
 # Base / pretrained weights: honor the config.yaml defaults unless overridden.

--- a/policy/X_WAM/transform_robodojo_to_xwam.py
+++ b/policy/X_WAM/transform_robodojo_to_xwam.py
@@ -29,6 +29,7 @@ Usage
     python XPolicyLab/policy/X_WAM/transform_robodojo_to_xwam.py \
         --input-dir  data/RoboDojo \
         --output-dir xwam_datasets/RoboDojo \
+        --env-cfg-type arx_x5 \
         --workers 16 [--limit 3] [--clean]
 """
 
@@ -219,13 +220,13 @@ def convert_one(job: dict) -> dict:
 # Job collection / main
 # ---------------------------------------------------------------------------
 
-def collect_jobs(input_dir: Path, out_dir: Path):
+def collect_jobs(input_dir: Path, out_dir: Path, env_cfg_type: str):
     """Scan all tasks' hdf5 files and assign globally-continuous indices, sorted by (task, in-task index)."""
     tasks = sorted(p.name for p in input_dir.iterdir() if p.is_dir())
     jobs = []
     global_index = 0
     for task_name in tasks:
-        data_dir = input_dir / task_name / "arx_x5" / "data"
+        data_dir = input_dir / task_name / env_cfg_type / "data"
         if not data_dir.is_dir():
             continue
         for src_index, ep_path in enumerate(sorted(data_dir.glob("episode_*.hdf5"))):
@@ -250,6 +251,8 @@ def main():
     parser.add_argument("--workers", type=int, default=16, help="number of parallel processes")
     parser.add_argument("--limit", type=int, default=0,
                         help="convert only the first N episodes (0 = all), for sampling")
+    parser.add_argument("--env-cfg-type", type=str, default="arx_x5",
+                        help="robot/environment config subdir under each task")
     parser.add_argument("--clean", action="store_true", help="clear the output directory before converting")
     args = parser.parse_args()
 
@@ -266,12 +269,12 @@ def main():
         shutil.rmtree(out_dir)
     (out_dir / "data").mkdir(parents=True, exist_ok=True)
 
-    jobs, tasks = collect_jobs(input_dir, out_dir)
+    jobs, tasks = collect_jobs(input_dir, out_dir, args.env_cfg_type)
     if args.limit > 0:
         jobs = jobs[:args.limit]
 
     print(f"[INFO] tasks: {len(tasks)} | episodes to convert: {len(jobs)} | "
-          f"workers: {args.workers} | output: {out_dir}")
+          f"env_cfg_type: {args.env_cfg_type} | workers: {args.workers} | output: {out_dir}")
 
     failures = []
     results = []

--- a/policy/Xiaomi_Robotics_0/README.md
+++ b/policy/Xiaomi_Robotics_0/README.md
@@ -42,7 +42,7 @@ cd XPolicyLab/policy/Xiaomi_Robotics_0
 # Example: install dependencies for the Xiaomi_Robotics_0 policy adapter.
 bash install.sh
 # Example: activate the environment used later as <policy_conda_env>.
-conda activate <policy_env>  # e.g. xiaomi-robotics-0
+conda activate <policy_env>  # default: mibot
 ```
 
 ## Demo Data Processing
@@ -56,20 +56,23 @@ Parameters used by the command:
 | `bench_name` | Benchmark or dataset family, usually `RoboDojo`. |
 | `ckpt_name` | Data/run identifier. Use a different value for ablations, for example `stack_bowls_50ep`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
-| `action_type` | Action representation, for example `joint`. |
+| `action_type` | Action representation returned to RoboDojo, usually `ee` or `joint`. |
 | `expert_data_num` | Optional episode limit. Leave unset to use all episodes. |
-| `raw_task_dirs` | Optional source task directory or comma-separated task list when the script supports it. |
+| `raw_task_dirs` | Optional source task directory or comma-separated task list. Defaults to `ckpt_name`; use it when the output run name differs from the raw task directory. |
 
 ```bash
 cd XPolicyLab/policy/Xiaomi_Robotics_0
 # Template: convert all available demonstrations for one run.
-bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type>
+bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> [expert_data_num] [raw_task_dirs]
 
-# Example: convert stack_bowls demos for arx_x5 joint control.
-bash process_data.sh RoboDojo stack_bowls arx_x5 joint
+# Example: convert all stack_bowls demos for arx_x5 end-effector control.
+bash process_data.sh RoboDojo stack_bowls arx_x5 ee
 
 # Example: create a 50-episode ablation while reading from the original task data.
-bash process_data.sh RoboDojo stack_bowls_50ep arx_x5 joint 50 stack_bowls
+bash process_data.sh RoboDojo stack_bowls_50ep arx_x5 ee 50 stack_bowls
+
+# Example: convert a named multi-task subset into one training dataset.
+bash process_data.sh RoboDojo pick_place_subset arx_x5 ee 100 stack_bowls,push_T
 ```
 
 ## Model Training
@@ -83,7 +86,7 @@ Parameters used by the command:
 | `bench_name` | Benchmark or dataset family, usually `RoboDojo`. |
 | `ckpt_name` | Training run identifier, for example `cotrain`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
-| `action_type` | Action representation, for example `joint`. |
+| `action_type` | Action representation returned to RoboDojo, usually `ee` or `joint`. |
 | `seed` | Random seed. |
 | `gpu_id` | GPU id or comma-separated GPU ids for the policy trainer. |
 
@@ -93,13 +96,13 @@ cd XPolicyLab/policy/Xiaomi_Robotics_0
 bash train.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> <seed> <gpu_id>
 
 # Example: train a cotrain run on GPU 0.
-bash train.sh RoboDojo cotrain arx_x5 joint 0 0
+bash train.sh RoboDojo cotrain arx_x5 ee 0 0
 
 # Example: train the same run on four GPUs if the upstream trainer supports it.
-bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3
+bash train.sh RoboDojo cotrain arx_x5 ee 0 0,1,2,3
 ```
 
-The usual checkpoint directory is `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`. Pass that full directory name as `ckpt_name` during evaluation.
+Training writes a standard checkpoint link at `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`. Pass that full directory name as `ckpt_name` during evaluation.
 
 ## Deployment and Evaluation
 
@@ -113,7 +116,7 @@ Parameters used by `eval.sh`:
 | `task_name` | RoboDojo simulation task to evaluate, for example `stack_bowls`. |
 | `ckpt_name` | Checkpoint/run directory name, usually under `checkpoints/`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
-| `action_type` | Action representation, for example `joint`. |
+| `action_type` | Action representation returned to RoboDojo, usually `ee` or `joint`. |
 | `seed` | Evaluation seed. |
 | `policy_gpu_id` | GPU used by the policy server. |
 | `env_gpu_id` | GPU used by the RoboDojo simulation client. |
@@ -126,7 +129,7 @@ cd XPolicyLab/policy/Xiaomi_Robotics_0
 bash eval.sh <bench_name> <task_name> <ckpt_name> <env_cfg_type> <action_type> <seed> <policy_gpu_id> <env_gpu_id> <policy_conda_env> <eval_env_conda_env>
 
 # Example: evaluate a trained cotrain checkpoint on stack_bowls.
-bash eval.sh RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-joint-0 arx_x5 joint 0 0 0 <policy_conda_env> <eval_env_conda_env>
+bash eval.sh RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-ee-0 arx_x5 ee 0 0 0 mibot <eval_env_conda_env>
 ```
 
 Parameters used by the split server/client flow:
@@ -137,7 +140,7 @@ Parameters used by the split server/client flow:
 | `task_name` | RoboDojo simulation task to evaluate, for example `stack_bowls`. |
 | `ckpt_name` | Checkpoint/run directory name, usually under `checkpoints/`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
-| `action_type` | Action representation, for example `joint`. |
+| `action_type` | Action representation returned to RoboDojo, usually `ee` or `joint`. |
 | `seed` | Evaluation seed. |
 | `policy_gpu_id` | GPU used by the policy server. |
 | `env_gpu_id` | GPU used by the RoboDojo simulation client. |
@@ -157,8 +160,8 @@ bash setup_eval_policy_server.sh \
 
 # Example: bind the policy server to all interfaces on port 5000.
 bash setup_eval_policy_server.sh \
-  RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-joint-0 arx_x5 joint 0 \
-  0 <policy_conda_env> 5000 0.0.0.0
+  RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-ee-0 arx_x5 ee 0 \
+  0 mibot 5000 0.0.0.0
 
 # Terminal 2 on the environment machine: connect RoboDojo to the policy server.
 bash setup_eval_env_client.sh \
@@ -168,8 +171,8 @@ bash setup_eval_env_client.sh \
 
 # Example: connect to a policy server reachable at <policy_server_ip>:5000.
 bash setup_eval_env_client.sh \
-  RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-joint-0 arx_x5 joint 0 \
-  0 <eval_env_conda_env> "ckpt_name=RoboDojo-cotrain-arx_x5-joint-0,action_type=joint" \
+  RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-ee-0 arx_x5 ee 0 \
+  0 <eval_env_conda_env> "ckpt_name=RoboDojo-cotrain-arx_x5-ee-0,action_type=ee" \
   5000 <policy_server_ip>
 ```
 
@@ -185,7 +188,7 @@ Common parameter meanings used across the commands above:
 | `task_name` | RoboDojo simulation task to evaluate, for example `stack_bowls`. |
 | `ckpt_name` | Checkpoint/run directory name, usually under `checkpoints/`. |
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
-| `action_type` | Action representation, for example `joint`. |
+| `action_type` | Action representation returned to RoboDojo, usually `ee` or `joint`. |
 | `seed` | Evaluation seed. |
 | `policy_gpu_id` | GPU used by the policy server. |
 | `env_gpu_id` | GPU used by the RoboDojo simulation client. |
@@ -204,25 +207,25 @@ Policy-specific `deploy.yml` keys worth checking before evaluation:
 | `vlm_processor_path` | Runtime or checkpoint option consumed by this adapter. |
 | `default_prompt` | Runtime or checkpoint option consumed by this adapter. |
 
-Frequently used environment variables detected in the adapter scripts:
+Frequently used environment variables:
 
 | Variable | Notes |
 |---|---|
-| `CONDA_ENV` | Optional override used by the local scripts or upstream runtime. |
-| `DEFAULT_VLM_PROCESSOR_REPO` | Optional override used by the local scripts or upstream runtime. |
-| `DEPLOY_PROXY_HOST` | Optional override used by the local scripts or upstream runtime. |
-| `DEPLOY_PROXY_PORT` | Optional override used by the local scripts or upstream runtime. |
-| `E402` | Optional override used by the local scripts or upstream runtime. |
-| `HDF5` | Optional override used by the local scripts or upstream runtime. |
-| `HF_HUB_OFFLINE` | Optional override used by the local scripts or upstream runtime. |
-| `HTTPS_PROXY` | Optional override used by the local scripts or upstream runtime. |
-| `HTTP_PROXY` | Optional override used by the local scripts or upstream runtime. |
-| `MIMODEL` | Optional override used by the local scripts or upstream runtime. |
-| `POLICY_DIR` | Optional override used by the local scripts or upstream runtime. |
-| `PROMPT_RE` | Optional override used by the local scripts or upstream runtime. |
+| `XR0_CONDA_ENV` | Optional environment name used by `install.sh`; default is `mibot`. |
+| `XR0_RAW_DATA_ROOT` | Required by `process_data.sh`; should contain `sim_cloud/<task>/<env_cfg_type>`. |
+| `XR0_CONVERTED_DATA_ROOT` | Optional output directory override for converted JSON/videos. |
+| `XR0_DATA_CONFIG_NAME` | Optional Hydra data config name override. |
+| `XR0_CONVERT_WORKERS` | Optional data conversion worker count; default is `8`. |
+| `XR0_PRETRAINED_PATH` | Optional converted XR-0 pretrained checkpoint path for training. |
+| `XR0_MAX_STEPS` | Optional training step count; default is `30000`. |
+| `XR0_SAVE_INTERVAL` | Optional checkpoint save interval; default is `5000`. |
+| `XR0_ASYNC_TRAIN` | Optional async-training switch; default is `false`. |
+| `DEPLOY_PROXY_HOST` / `DEPLOY_PROXY_PORT` | Optional HuggingFace/proxy settings used by the policy server. |
+| `HF_HUB_OFFLINE` / `TRANSFORMERS_OFFLINE` | Optional offline deploy switches. |
 
 ## Notes
 
-- Keep `ckpt_name` stable between data processing, training, and evaluation. For data-size ablations, encode the subset in `ckpt_name` such as `stack_bowls_50ep`.
+- Use the same short `ckpt_name` between data processing and training. For data-size ablations, encode the subset in `ckpt_name` such as `stack_bowls_50ep` and pass the source task through `raw_task_dirs`.
+- Evaluation uses the full checkpoint directory name as `ckpt_name`, for example `RoboDojo-cotrain-arx_x5-ee-0`, unless `model_dir` in `deploy.yml` points somewhere else.
 - `task_name` is only the evaluation task; multi-task checkpoints can be evaluated on different tasks without renaming the checkpoint directory.
 - Prefer running `setup_eval_policy_server.sh` and `setup_eval_env_client.sh` separately when debugging dependency, CUDA, or model-loading issues.

--- a/policy/Xiaomi_Robotics_0/process_data.sh
+++ b/policy/Xiaomi_Robotics_0/process_data.sh
@@ -2,8 +2,9 @@
 set -euo pipefail
 
 if [[ $# -lt 4 ]]; then
-  echo "Usage: $0 <bench_name> <ckpt_name> <env_cfg_type> <action_type> [expert_data_num]" >&2
+  echo "Usage: $0 <bench_name> <ckpt_name> <env_cfg_type> <action_type> [expert_data_num] [raw_task_dirs]" >&2
   echo "  expert_data_num: optional; empty = use all episodes" >&2
+  echo "  raw_task_dirs: optional source task dir or comma-separated task dirs; defaults to ckpt_name" >&2
   exit 1
 fi
 
@@ -12,6 +13,11 @@ ckpt_name=$2
 env_cfg_type=$3
 action_type=$4
 expert_data_num=${5:-}
+raw_task_dirs=${6:-}
+if [[ -n "${expert_data_num}" && ! "${expert_data_num}" =~ ^[0-9]+$ ]]; then
+  raw_task_dirs="${expert_data_num}"
+  expert_data_num=""
+fi
 
 POLICY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 XR0_ROOT="${POLICY_DIR}/xiaomi_robotics_0/xr0"
@@ -25,18 +31,61 @@ if [[ -z "${raw_data_root}" ]]; then
 fi
 data_config_name="${XR0_DATA_CONFIG_NAME:-${data_setting}}"
 
-resolve_single_input_dir() {
-  if [[ "${bench_name}" == "RoboDojo" && -d "${raw_data_root}/sim_cloud/${ckpt_name}/${env_cfg_type}" ]]; then
-    echo "${raw_data_root}/sim_cloud/${ckpt_name}/${env_cfg_type}"
+resolve_task_input_dir() {
+  local task_dir_name=$1
+  if [[ "${bench_name}" == "RoboDojo" && -d "${raw_data_root}/sim_cloud/${task_dir_name}/${env_cfg_type}" ]]; then
+    echo "${raw_data_root}/sim_cloud/${task_dir_name}/${env_cfg_type}"
     return
   fi
-  if [[ -d "${raw_data_root}/${bench_name}/${ckpt_name}/${env_cfg_type}" ]]; then
-    echo "${raw_data_root}/${bench_name}/${ckpt_name}/${env_cfg_type}"
+  if [[ -d "${raw_data_root}/${bench_name}/${task_dir_name}/${env_cfg_type}" ]]; then
+    echo "${raw_data_root}/${bench_name}/${task_dir_name}/${env_cfg_type}"
     return
   fi
-  echo "Input directory not found for ${bench_name}/${ckpt_name}/${env_cfg_type}" >&2
-  echo "Set XR0_RAW_DATA_ROOT or check ckpt_name." >&2
+  echo "Input directory not found for ${bench_name}/${task_dir_name}/${env_cfg_type}" >&2
+  echo "Set XR0_RAW_DATA_ROOT or check raw_task_dirs/ckpt_name." >&2
   exit 1
+}
+
+link_task_episodes() {
+  local source_dir=$1
+  local staging_dir=$2
+  local output_prefix=$3
+  local hdf5_path count=0
+
+  shopt -s nullglob
+  for hdf5_path in "${source_dir}"/*.hdf5 "${source_dir}"/*.h5; do
+    ln -sf "$(readlink -f "${hdf5_path}")" "${staging_dir}/${output_prefix}$(basename "${hdf5_path}")"
+    count=$((count + 1))
+    if [[ -n "${expert_data_num}" && "${count}" -ge "${expert_data_num}" ]]; then
+      break
+    fi
+  done
+  shopt -u nullglob
+
+  echo "${count}"
+}
+
+build_staging_dir_from_task_list() {
+  local task_list=$1
+  local staging_dir="${converted_data_root}/.raw_staging"
+  rm -rf "${staging_dir}"
+  mkdir -p "${staging_dir}"
+
+  local task_name source_dir linked_count total_count=0
+  IFS=',' read -r -a task_names <<< "${task_list}"
+  for task_name in "${task_names[@]}"; do
+    task_name="$(echo "${task_name}" | xargs)"
+    [[ -n "${task_name}" ]] || continue
+    source_dir="$(resolve_task_input_dir "${task_name}")"
+    linked_count="$(link_task_episodes "${source_dir}" "${staging_dir}" "${task_name}_")"
+    total_count=$((total_count + linked_count))
+  done
+
+  if [[ "${total_count}" -eq 0 ]]; then
+    echo "No .hdf5 or .h5 files found for raw_task_dirs=${task_list}" >&2
+    exit 1
+  fi
+  echo "${staging_dir}"
 }
 
 build_cotrain_staging_dir() {
@@ -50,56 +99,36 @@ build_cotrain_staging_dir() {
     exit 1
   fi
 
-  local task_dir env_dir task_name hdf5_path count
+  local task_dir env_dir task_name total_count=0 linked_count
   for task_dir in "${sim_root}"/*; do
     [[ -d "${task_dir}" ]] || continue
     env_dir="${task_dir}/${env_cfg_type}"
     [[ -d "${env_dir}" ]] || continue
     task_name="$(basename "${task_dir}")"
-    count=0
-    shopt -s nullglob
-    for hdf5_path in "${env_dir}"/*.hdf5 "${env_dir}"/*.h5; do
-      ln -sf "$(readlink -f "${hdf5_path}")" "${staging_dir}/${task_name}_$(basename "${hdf5_path}")"
-      count=$((count + 1))
-      if [[ -n "${expert_data_num}" && "${count}" -ge "${expert_data_num}" ]]; then
-        break
-      fi
-    done
-    shopt -u nullglob
+    linked_count="$(link_task_episodes "${env_dir}" "${staging_dir}" "${task_name}_")"
+    total_count=$((total_count + linked_count))
   done
 
-  echo "${staging_dir}"
-}
-
-build_single_staging_dir() {
-  local source_dir=$1
-  local staging_dir="${converted_data_root}/.raw_staging"
-  rm -rf "${staging_dir}"
-  mkdir -p "${staging_dir}"
-
-  local hdf5_path count=0
-  shopt -s nullglob
-  for hdf5_path in "${source_dir}"/*.hdf5 "${source_dir}"/*.h5; do
-    ln -sf "$(readlink -f "${hdf5_path}")" "${staging_dir}/$(basename "${hdf5_path}")"
-    count=$((count + 1))
-    if [[ -n "${expert_data_num}" && "${count}" -ge "${expert_data_num}" ]]; then
-      break
-    fi
-  done
-  shopt -u nullglob
-
+  if [[ "${total_count}" -eq 0 ]]; then
+    echo "No .hdf5 or .h5 files found under ${sim_root}/*/${env_cfg_type}" >&2
+    exit 1
+  fi
   echo "${staging_dir}"
 }
 
 resolve_input_dir() {
+  if [[ -n "${raw_task_dirs}" ]]; then
+    build_staging_dir_from_task_list "${raw_task_dirs}"
+    return
+  fi
   if [[ "${ckpt_name}" == "cotrain" ]]; then
     build_cotrain_staging_dir
     return
   fi
   local single_dir
-  single_dir="$(resolve_single_input_dir)"
+  single_dir="$(resolve_task_input_dir "${ckpt_name}")"
   if [[ -n "${expert_data_num}" ]]; then
-    build_single_staging_dir "${single_dir}"
+    build_staging_dir_from_task_list "${ckpt_name}"
     return
   fi
   echo "${single_dir}"
@@ -109,6 +138,7 @@ echo "[Xiaomi_Robotics_0] bench_name=${bench_name}"
 echo "[Xiaomi_Robotics_0] ckpt_name=${ckpt_name}"
 echo "[Xiaomi_Robotics_0] env_cfg_type=${env_cfg_type}"
 echo "[Xiaomi_Robotics_0] expert_data_num=${expert_data_num:-<all>}"
+echo "[Xiaomi_Robotics_0] raw_task_dirs=${raw_task_dirs:-<ckpt_name>}"
 echo "[Xiaomi_Robotics_0] action_type=${action_type}"
 echo "[Xiaomi_Robotics_0] raw_data_root=${raw_data_root}"
 echo "[Xiaomi_Robotics_0] converted_data_root=${converted_data_root}"

--- a/policy/starVLA/README.md
+++ b/policy/starVLA/README.md
@@ -54,7 +54,7 @@ Parameters used by the command:
 | `env_cfg_type` | Robot/environment configuration, for example `arx_x5`. |
 | `action_type` | Action representation, for example `joint`. |
 | `expert_data_num` | Optional episode limit. Leave unset to use all episodes. |
-| `raw_task_dirs` | Optional source task directory or comma-separated task list when the script supports it. |
+| `raw_task_dirs` | Optional source task directory or comma-separated task list under `data/<bench_name>/`. Defaults to `ckpt_name`. |
 
 ```bash
 cd XPolicyLab/policy/starVLA
@@ -66,7 +66,12 @@ bash process_data.sh RoboDojo stack_bowls arx_x5 joint
 
 # Example: create a 50-episode ablation while reading from the original task data.
 bash process_data.sh RoboDojo stack_bowls_50ep arx_x5 joint 50 stack_bowls
+
+# Example: rename the output while using all episodes from the original task data.
+bash process_data.sh RoboDojo stack_bowls_full arx_x5 joint stack_bowls
 ```
+
+The converted LeRobot dataset is written to `data/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>/`. Use the same `ckpt_name` when launching `train.sh`, unless you also set `STARVLA_XPOLICY_DATASET_NAME` explicitly.
 
 ## Model Training
 
@@ -88,11 +93,11 @@ cd XPolicyLab/policy/starVLA
 # Template: train a policy run on one GPU or a GPU list.
 bash train.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> <seed> <gpu_id>
 
-# Example: train a cotrain run on GPU 0.
-bash train.sh RoboDojo cotrain arx_x5 joint 0 0
+# Example: train the converted stack_bowls dataset on GPU 0.
+bash train.sh RoboDojo stack_bowls arx_x5 joint 0 0
 
 # Example: train the same run on four GPUs if the upstream trainer supports it.
-bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3
+bash train.sh RoboDojo stack_bowls arx_x5 joint 0 0,1,2,3
 ```
 
 The usual checkpoint directory is `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`. Pass that full directory name as `ckpt_name` during evaluation.
@@ -121,8 +126,8 @@ cd XPolicyLab/policy/starVLA
 # Template: run same-machine policy server and RoboDojo environment client.
 bash eval.sh <bench_name> <task_name> <ckpt_name> <env_cfg_type> <action_type> <seed> <policy_gpu_id> <env_gpu_id> <policy_conda_env> <eval_env_conda_env>
 
-# Example: evaluate a trained cotrain checkpoint on stack_bowls.
-bash eval.sh RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-joint-0 arx_x5 joint 0 0 0 <policy_conda_env> <eval_env_conda_env>
+# Example: evaluate a trained stack_bowls checkpoint.
+bash eval.sh RoboDojo stack_bowls RoboDojo-stack_bowls-arx_x5-joint-0 arx_x5 joint 0 0 0 <policy_conda_env> <eval_env_conda_env>
 ```
 
 Parameters used by the split server/client flow:
@@ -153,7 +158,7 @@ bash setup_eval_policy_server.sh \
 
 # Example: bind the policy server to all interfaces on port 5000.
 bash setup_eval_policy_server.sh \
-  RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-joint-0 arx_x5 joint 0 \
+  RoboDojo stack_bowls RoboDojo-stack_bowls-arx_x5-joint-0 arx_x5 joint 0 \
   0 <policy_conda_env> 5000 0.0.0.0
 
 # Terminal 2 on the environment machine: connect RoboDojo to the policy server.
@@ -164,8 +169,8 @@ bash setup_eval_env_client.sh \
 
 # Example: connect to a policy server reachable at <policy_server_ip>:5000.
 bash setup_eval_env_client.sh \
-  RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-joint-0 arx_x5 joint 0 \
-  0 <eval_env_conda_env> "ckpt_name=RoboDojo-cotrain-arx_x5-joint-0,action_type=joint" \
+  RoboDojo stack_bowls RoboDojo-stack_bowls-arx_x5-joint-0 arx_x5 joint 0 \
+  0 <eval_env_conda_env> "ckpt_name=RoboDojo-stack_bowls-arx_x5-joint-0,action_type=joint" \
   5000 <policy_server_ip>
 ```
 

--- a/policy/starVLA/process_data.sh
+++ b/policy/starVLA/process_data.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 set -euo pipefail
 
-# Usage: bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> [expert_data_num]
+# Usage: bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> [expert_data_num] [raw_task_dirs]
 # expert_data_num: optional; empty = use all episodes
+# raw_task_dirs: optional; source task dir(s) under data/<bench_name>/, comma-separated
 
 if [[ $# -lt 4 ]]; then
-    echo "Usage: bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> [expert_data_num]" >&2
+    echo "Usage: bash process_data.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> [expert_data_num] [raw_task_dirs]" >&2
     echo "Example: bash process_data.sh RoboDojo stack_bowls arx_x5 joint" >&2
-    echo "Example: bash process_data.sh RoboDojo stack_bowls arx_x5 joint 50" >&2
+    echo "Example: bash process_data.sh RoboDojo stack_bowls_50ep arx_x5 joint 50 stack_bowls" >&2
     exit 1
 fi
 
@@ -16,12 +17,17 @@ ckpt_name=${2}
 env_cfg_type=${3}
 action_type=${4}
 expert_data_num=${5:-}
+raw_task_dirs=${6:-}
+if [[ -n "${expert_data_num}" && ! "${expert_data_num}" =~ ^[0-9]+$ ]]; then
+    raw_task_dirs="${expert_data_num}"
+    expert_data_num=""
+fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 out_tag="${bench_name}-${ckpt_name}-${env_cfg_type}-${action_type}"
 
-echo "[process_data] ${bench_name}/${ckpt_name}/${env_cfg_type} expert_data_num=${expert_data_num:-<all>} (${action_type}) -> data/${out_tag}/"
+echo "[process_data] ${bench_name}/${ckpt_name}/${env_cfg_type} expert_data_num=${expert_data_num:-<all>} raw_task_dirs=${raw_task_dirs:-${ckpt_name}} (${action_type}) -> data/${out_tag}/"
 
 py_args=(
     "${SCRIPT_DIR}/source_starvla/examples/XPolicyLab/train_files/convert_xpolicy_to_lerobot3.py"
@@ -34,6 +40,9 @@ py_args=(
 )
 if [[ -n "${expert_data_num}" ]]; then
     py_args+=(--expert_data_num "${expert_data_num}")
+fi
+if [[ -n "${raw_task_dirs}" ]]; then
+    py_args+=(--raw_task_dirs "${raw_task_dirs}")
 fi
 
 python "${py_args[@]}"

--- a/policy/starVLA/source_starvla/examples/XPolicyLab/train_files/convert_xpolicy_to_lerobot3.py
+++ b/policy/starVLA/source_starvla/examples/XPolicyLab/train_files/convert_xpolicy_to_lerobot3.py
@@ -188,6 +188,7 @@ def _write_info_json(
     total_episodes: int,
     total_frames: int,
     total_videos: int,
+    total_tasks: int,
     fps: int,
 ) -> None:
     info = {
@@ -195,7 +196,7 @@ def _write_info_json(
         "robot_type": "unified_robot",
         "total_episodes": total_episodes,
         "total_frames": total_frames,
-        "total_tasks": 1,
+        "total_tasks": total_tasks,
         "chunks_size": 1000,
         "data_files_size_in_mb": 100,
         "video_files_size_in_mb": 200,
@@ -263,19 +264,21 @@ def convert(args: argparse.Namespace) -> None:
         raise NotImplementedError("First starVLA converter supports arx_x5 + joint only.")
     robot_action_dim_info = get_robot_action_dim_info(args.env_cfg_type)
 
-    source_dir = (
-        Path(args.root_dir).resolve()
-        / "data"
-        / args.bench_name
-        / args.ckpt_name
-        / args.env_cfg_type
-    )
-    hdf5_dir = source_dir / "data"
-    if not hdf5_dir.is_dir():
-        raise FileNotFoundError(f"Missing XPolicy HDF5 data dir: {hdf5_dir}")
+    source_root = Path(args.root_dir).resolve() / "data" / args.bench_name
+    raw_task_dirs = [
+        task_dir.strip()
+        for task_dir in (args.raw_task_dirs or args.ckpt_name).split(",")
+        if task_dir.strip()
+    ]
+    episode_sources: list[tuple[str, Path]] = []
+    for raw_task_dir in raw_task_dirs:
+        hdf5_dir = source_root / raw_task_dir / args.env_cfg_type / "data"
+        if not hdf5_dir.is_dir():
+            raise FileNotFoundError(f"Missing XPolicy HDF5 data dir: {hdf5_dir}")
+        episode_sources.extend((raw_task_dir, path) for path in sorted(hdf5_dir.glob("episode_*.hdf5")))
 
     output_root = Path(args.output_dir).resolve()
-    dataset_dir = output_root / "arx_x5"
+    dataset_dir = output_root
     if dataset_dir.exists() and not args.keep_existing:
         shutil.rmtree(dataset_dir)
 
@@ -284,29 +287,33 @@ def convert(args: argparse.Namespace) -> None:
     data_chunk_dir.mkdir(parents=True, exist_ok=True)
     episode_meta_dir.mkdir(parents=True, exist_ok=True)
 
-    episode_paths = sorted(hdf5_dir.glob("episode_*.hdf5"))
     if args.expert_data_num is not None and int(args.expert_data_num) > 0:
-        episode_paths = episode_paths[: int(args.expert_data_num)]
-    if not episode_paths:
-        raise FileNotFoundError(f"No episode_*.hdf5 files found in {hdf5_dir}")
+        episode_sources = episode_sources[: int(args.expert_data_num)]
+    if not episode_sources:
+        searched = ", ".join(
+            str(source_root / raw_task_dir / args.env_cfg_type / "data")
+            for raw_task_dir in raw_task_dirs
+        )
+        raise FileNotFoundError(f"No episode_*.hdf5 files found under: {searched}")
 
     all_rows = []
     episode_rows = []
-    task_instruction = args.ckpt_name.replace("_", " ")
+    task_to_index: dict[str, int] = {}
     total_frames = 0
     total_videos = 0
     fps = 30
 
     episode_iter = tqdm(
-        enumerate(episode_paths),
-        total=len(episode_paths),
+        enumerate(episode_sources),
+        total=len(episode_sources),
         desc="[starVLA] episodes",
         unit="episode",
     )
-    for episode_index, episode_path in episode_iter:
+    for episode_index, (raw_task_dir, episode_path) in episode_iter:
         with h5py.File(episode_path, "r") as h5_file:
-            instruction = _read_instruction(h5_file, task_instruction)
-            task_instruction = instruction or task_instruction
+            fallback_instruction = raw_task_dir.replace("_", " ")
+            instruction = _read_instruction(h5_file, fallback_instruction) or fallback_instruction
+            task_index = task_to_index.setdefault(instruction, len(task_to_index))
             fps = int(np.asarray(h5_file["additional_info"]["frequency"]).item())
 
             dataset_like = {
@@ -362,7 +369,7 @@ def convert(args: argparse.Namespace) -> None:
                     "episode_index": episode_index,
                     "frame_index": frame_index,
                     "timestamp": frame_index / float(fps),
-                    "task_index": 0,
+                    "task_index": task_index,
                     "index": global_frame_index,
                     "observation.state": state[frame_index].astype(np.float32),
                     "action": action[frame_index].astype(np.float32),
@@ -372,7 +379,7 @@ def convert(args: argparse.Namespace) -> None:
             episode_row = {
                 "episode_index": episode_index,
                 "length": length,
-                "tasks": [task_instruction],
+                "tasks": [instruction],
                 "data/chunk_index": 0,
                 "data/file_index": 0,
                 "data/file_from_index": total_frames,
@@ -387,7 +394,10 @@ def convert(args: argparse.Namespace) -> None:
     pd.DataFrame(all_rows).to_parquet(data_chunk_dir / "file-000.parquet", index=False)
     pd.DataFrame(episode_rows).to_parquet(episode_meta_dir / "file-000.parquet", index=False)
 
-    tasks = pd.DataFrame({"task_index": [0]}, index=[task_instruction])
+    tasks = pd.DataFrame(
+        {"task_index": list(task_to_index.values())},
+        index=list(task_to_index.keys()),
+    )
     tasks.to_parquet(dataset_dir / "meta" / "tasks.parquet")
 
     _write_modality_json(dataset_dir)
@@ -396,11 +406,12 @@ def convert(args: argparse.Namespace) -> None:
         total_episodes=len(episode_rows),
         total_frames=total_frames,
         total_videos=total_videos,
+        total_tasks=len(task_to_index),
         fps=fps,
     )
 
     print(f"[starVLA] wrote LeRobot v3 dataset: {dataset_dir}")
-    print(f"[starVLA] episodes={len(episode_rows)}, frames={total_frames}, task={task_instruction!r}")
+    print(f"[starVLA] episodes={len(episode_rows)}, frames={total_frames}, tasks={list(task_to_index)}")
 
 
 def build_argparser() -> argparse.ArgumentParser:
@@ -411,6 +422,11 @@ def build_argparser() -> argparse.ArgumentParser:
     parser.add_argument("--env_cfg_type", required=True)
     parser.add_argument("--expert_data_num", type=int, default=None,
                         help="Optional episode cap; omit to use all episodes.")
+    parser.add_argument(
+        "--raw_task_dirs",
+        default=None,
+        help="Optional source task dir(s) under data/<bench_name>/; comma-separated. Defaults to ckpt_name.",
+    )
     parser.add_argument("--action_type", required=True)
     parser.add_argument("--output_dir", required=True)
     parser.add_argument("--keep_existing", action="store_true")

--- a/policy/starVLA/train.sh
+++ b/policy/starVLA/train.sh
@@ -26,9 +26,16 @@ data_root_dir="${STARVLA_DATA_ROOT:-${SCRIPT_DIR}/data}"
 data_mix="${STARVLA_DATA_MIX:-xpolicylab_runtime}"
 dataset_name="${STARVLA_XPOLICY_DATASET_NAME:-${data_dir_name}}"
 config_yaml="${SCRIPT_DIR}/.generated/xpolicy_oft_vla_${run_id}.yaml"
+dataset_path="${data_root_dir}/${dataset_name}"
 
-if [[ ! -d "${data_root_dir}/${dataset_name}" ]]; then
-    echo "[starVLA][ERROR] dataset not found: ${data_root_dir}/${dataset_name}" >&2
+if [[ ! -f "${dataset_path}/meta/modality.json" && -f "${dataset_path}/${env_cfg_type}/meta/modality.json" ]]; then
+    dataset_name="${dataset_name}/${env_cfg_type}"
+    dataset_path="${data_root_dir}/${dataset_name}"
+fi
+
+if [[ ! -f "${dataset_path}/meta/modality.json" ]]; then
+    echo "[starVLA][ERROR] LeRobot dataset not found or incomplete: ${dataset_path}" >&2
+    echo "[starVLA][ERROR] expected ${dataset_path}/meta/modality.json" >&2
     echo "[starVLA][ERROR] Run process_data.sh first, or set STARVLA_DATA_ROOT/STARVLA_XPOLICY_DATASET_NAME." >&2
     exit 1
 fi
@@ -55,7 +62,7 @@ echo "[starVLA] config_yaml=${config_yaml}"
 echo "[starVLA] run_id=${run_id}"
 echo "[starVLA] seed=${seed}"
 echo "[starVLA] data_root_dir=${data_root_dir}"
-echo "[starVLA] data_mix=${data_mix}, dataset=${dataset_name}"
+echo "[starVLA] data_mix=${data_mix}, dataset=${dataset_name}, dataset_path=${dataset_path}"
 echo "[starVLA] train_entry=starVLA/training/train_starvla.py"
 echo "[starVLA] num_processes=${num_processes}, mixed_precision=bf16"
 


### PR DESCRIPTION
Split out from the absolute-path cleanup. These changes touch policy training/data-processing/eval behavior (not just paths):

- Pi_0/Pi_05/starVLA/TinyVLA/Xiaomi/X_WAM process_data: multi-task raw_task_dirs support (default falls back to ckpt_name for backward compatibility); Pi_0 decodes HDF5 instructions; starVLA converter writes multi-task task_index and flattens output dir.
- Pi_0/Pi_05 train.sh: pass data.repo-id (and Pi_05 fsdp-devices) so process_data output is wired into training.
- OpenVLA_OFT/Spirit_v15/SmolVLA/DP model.py: harden checkpoint resolution and fail loudly instead of silently loading base weights; DP tracks the real env_idx from the latest obs.
- Spirit_v15 deploy.yml: force_default_task_name false.
- X_VLA/RDT_1B: fix deploy policy path and mkdir typo.
- Refresh affected policy READMEs.