### PR TITLE
[policy] feat: support StarVLA framework variants

### DIFF
--- a/policy/starVLA/README.md
+++ b/policy/starVLA/README.md
@@ -34,8 +34,8 @@ same interface:
   ARX X5 absolute-joint state ordered as left arm, left gripper, right arm,
   and right gripper.
 - Normalize state with the checkpoint's `arx_x5` training statistics before
-  model inference. The gripper dimensions must use the same binary handling
-  as training.
+  model inference. The 50-step RoboDojo schema uses q99 normalization for all
+  dimensions, including the continuous grippers.
 - Return normalized actions with shape `[batch, horizon, 14]` and expose
   `action_chunk_size` through websocket server metadata. The runtime must
   unnormalize actions with the matching `arx_x5` statistics before returning
@@ -45,6 +45,16 @@ same interface:
 
 A separate checkout can be supplied through `starvla_root`; checkpoints and
 normalization statistics are user-provided and are not included here.
+
+Released checkpoints should retain their run-directory layout so the runtime
+can find `config.yaml`, `config.full.yaml`, and `dataset_statistics.json` next
+to the `checkpoints/` directory. The public data-mixture name is
+`robodojo_arx_x5_h50_q99`; `robodojo_v21_all_h50_q99` remains supported as a
+compatibility alias.
+
+`include_state: auto` reads `datasets.vla_data.include_state` from
+`config.yaml`, then falls back to `config.full.yaml` and finally `false`.
+`STARVLA_INCLUDE_STATE` remains the highest-priority explicit override.
 
 `starVLA` is the XPolicyLab/RoboDojo adapter for the corresponding policy. It keeps integration-facing scripts at this directory level and leaves the original or vendored implementation in the nested source tree when present.
 
@@ -62,6 +72,7 @@ normalization statistics are user-provided and are not included here.
 | `setup_eval_env_client.sh` | Starts only the RoboDojo environment client and connects to a policy server. |
 | `deploy.py` | Policy wrapper used by the XPolicyLab model server. |
 | `model.py` | Model adapter loaded by `deploy.py` or the policy server. |
+| `runtime_config.py` | Resolves checkpoint-driven inference options such as `include_state`. |
 | `deploy.yml` | Runtime configuration and default checkpoint/model parameters. |
 | `source_starvla/` | Vendored upstream code, policy-specific assets, or helper scripts. |
 
@@ -251,7 +262,7 @@ Policy-specific `deploy.yml` keys worth checking before evaluation:
 | `num_ddim_steps` | Runtime or checkpoint option consumed by this adapter. |
 | `image_size` | Runtime or checkpoint option consumed by this adapter. |
 | `execute_horizon` | Number of actions executed before requesting a new predicted chunk. |
-| `include_state` | Runtime or checkpoint option consumed by this adapter. |
+| `include_state` | `auto` reads the checkpoint config; an explicit boolean overrides it. |
 
 Frequently used environment variables detected in the adapter scripts:
 
@@ -265,7 +276,7 @@ Frequently used environment variables detected in the adapter scripts:
 | `STARVLA_CKPT_PATH` | Optional override used by the local scripts or upstream runtime. |
 | `STARVLA_EXECUTE_HORIZON` | Overrides the number of actions executed from each predicted chunk. |
 | `STARVLA_IMAGE_SIZE` | Overrides the input image size passed to the adapter. |
-| `STARVLA_INCLUDE_STATE` | Enables or disables proprioceptive state input. |
+| `STARVLA_INCLUDE_STATE` | Explicitly overrides checkpoint-driven proprioceptive state selection. |
 | `STARVLA_ROOT` | Optional override used by the local scripts or upstream runtime. |
 | `STARVLA_SERVER_PID` | Optional override used by the local scripts or upstream runtime. |
 | `STARVLA_UNNORM_KEY` | Selects the checkpoint normalization statistics. |

--- a/policy/starVLA/README.md
+++ b/policy/starVLA/README.md
@@ -2,6 +2,50 @@
 
 **Contributor:** RoboDojo Team | **Paper:** StarVLA: A Versatile Vision-Language-Action Model with Efficient Training and Policy Adaptation | **arXiv:** https://arxiv.org/abs/2604.05014 | **Original code:** https://github.com/starVLA/starVLA
 
+## Supported Variants
+
+The adapter exposes three StarVLA variants that share the public
+`Qwen3-VL-4B-Instruct` visual-language backbone:
+
+| Public name | StarVLA framework registry | Action head |
+|---|---|---|
+| `starVLA-OFT` | `QwenOFT` | MLP regression head over action-token hidden states |
+| `starVLA-GR00T` | `QwenGR00T` | Flow-matching DiT action head |
+| `starVLA-π` | `QwenPI_v3` | Layer-wise cross-DiT flow-matching action head |
+
+These names are reporting labels. All three variants use `starVLA` as the
+XPolicyLab runtime `policy_name`; the selected checkpoint identifies the
+framework implementation. The action-policy components are trained from
+scratch, while Qwen3-VL-4B-Instruct is used as the public backbone
+initialization. No internal robot data, private demonstrations, hidden VLA
+pretraining, or unreleased pretrained policy weights are required by this
+adapter.
+
+## External StarVLA Runtime Contract
+
+The vendored `source_starvla` runtime implements the inference-side contract
+below. A separate checkout supplied through `starvla_root` must provide the
+same interface:
+
+- Register `QwenOFT`, `QwenGR00T`, and `QwenPI_v3` and reconstruct the
+  framework selected by the checkpoint configuration.
+- Accept three RGB observations (`cam_head`, `cam_left_wrist`, and
+  `cam_right_wrist`), a language instruction, and an optional 14-dimensional
+  ARX X5 absolute-joint state ordered as left arm, left gripper, right arm,
+  and right gripper.
+- Normalize state with the checkpoint's `arx_x5` training statistics before
+  model inference. The gripper dimensions must use the same binary handling
+  as training.
+- Return normalized actions with shape `[batch, horizon, 14]` and expose
+  `action_chunk_size` through websocket server metadata. The runtime must
+  unnormalize actions with the matching `arx_x5` statistics before returning
+  them to XPolicyLab.
+- Support a 50-step predicted action chunk. RoboDojo executes the first 16
+  actions and then requests a new chunk.
+
+A separate checkout can be supplied through `starvla_root`; checkpoints and
+normalization statistics are user-provided and are not included here.
+
 `starVLA` is the XPolicyLab/RoboDojo adapter for the corresponding policy. It keeps integration-facing scripts at this directory level and leaves the original or vendored implementation in the nested source tree when present.
 
 <details>
@@ -206,6 +250,7 @@ Policy-specific `deploy.yml` keys worth checking before evaluation:
 | `use_ddim` | Runtime or checkpoint option consumed by this adapter. |
 | `num_ddim_steps` | Runtime or checkpoint option consumed by this adapter. |
 | `image_size` | Runtime or checkpoint option consumed by this adapter. |
+| `execute_horizon` | Number of actions executed before requesting a new predicted chunk. |
 | `include_state` | Runtime or checkpoint option consumed by this adapter. |
 
 Frequently used environment variables detected in the adapter scripts:
@@ -218,8 +263,12 @@ Frequently used environment variables detected in the adapter scripts:
 | `NO_ALBUMENTATIONS_UPDATE` | Optional override used by the local scripts or upstream runtime. |
 | `PYTHONWARNINGS` | Optional override used by the local scripts or upstream runtime. |
 | `STARVLA_CKPT_PATH` | Optional override used by the local scripts or upstream runtime. |
+| `STARVLA_EXECUTE_HORIZON` | Overrides the number of actions executed from each predicted chunk. |
+| `STARVLA_IMAGE_SIZE` | Overrides the input image size passed to the adapter. |
+| `STARVLA_INCLUDE_STATE` | Enables or disables proprioceptive state input. |
 | `STARVLA_ROOT` | Optional override used by the local scripts or upstream runtime. |
 | `STARVLA_SERVER_PID` | Optional override used by the local scripts or upstream runtime. |
+| `STARVLA_UNNORM_KEY` | Selects the checkpoint normalization statistics. |
 | `TASK_ENV` | Optional override used by the local scripts or upstream runtime. |
 | `TRANSFORMERS_VERBOSITY` | Optional override used by the local scripts or upstream runtime. |
 | `WANDB_MODE` | Optional override used by the local scripts or upstream runtime. |

--- a/policy/starVLA/deploy.yml
+++ b/policy/starVLA/deploy.yml
@@ -22,4 +22,4 @@ use_ddim: true
 num_ddim_steps: 10
 image_size: [224, 224]
 execute_horizon: 16
-include_state: false
+include_state: auto

--- a/policy/starVLA/deploy.yml
+++ b/policy/starVLA/deploy.yml
@@ -17,8 +17,9 @@ starvla_root: source_starvla
 checkpoint_path: null
 starvla_server_host: 127.0.0.1
 starvla_server_port: 5694
-unnorm_key: new_embodiment
+unnorm_key: arx_x5
 use_ddim: true
 num_ddim_steps: 10
 image_size: [224, 224]
+execute_horizon: 16
 include_state: false

--- a/policy/starVLA/model.py
+++ b/policy/starVLA/model.py
@@ -13,6 +13,7 @@ from XPolicyLab.utils.process_data import (
     pack_robot_state,
     unpack_robot_state,
 )
+from .runtime_config import resolve_include_state
 
 
 _CUR_DIR = Path(__file__).resolve().parent
@@ -120,7 +121,10 @@ class Model(ModelTemplate):
         self.use_ddim = bool(self.model_cfg.get("use_ddim", True))
         self.num_ddim_steps = int(self.model_cfg.get("num_ddim_steps", 10))
         self.image_size = tuple(self.model_cfg.get("image_size", [224, 224]))
-        self.include_state = bool(self.model_cfg.get("include_state", False))
+        self.include_state = resolve_include_state(
+            self.model_cfg.get("include_state", "auto"),
+            self.model_cfg.get("checkpoint_path"),
+        )
 
         self.obs_by_env: dict[int, dict[str, Any]] = {}
         self.action_chunks_by_env: dict[int, np.ndarray] = {}
@@ -130,7 +134,7 @@ class Model(ModelTemplate):
         print(
             f"[starVLA] connected to StarVLA server, action_dim={self.action_dim}, "
             f"chunk={self.action_chunk_size}, execute_horizon={self.execute_horizon}, "
-            f"action_order=xpolicy, metadata={server_meta}"
+            f"include_state={self.include_state}, action_order=xpolicy, metadata={server_meta}"
         )
 
     def _convert_obs(self, observation: dict[str, Any]) -> dict[str, Any]:

--- a/policy/starVLA/model.py
+++ b/policy/starVLA/model.py
@@ -104,7 +104,19 @@ class Model(ModelTemplate):
         )
         server_meta = self.client.get_server_metadata()
         self.action_chunk_size = int(server_meta["action_chunk_size"])
-        self.unnorm_key = self.model_cfg.get("unnorm_key", "new_embodiment")
+        execute_horizon = self.model_cfg.get("execute_horizon", self.action_chunk_size)
+        if execute_horizon in (None, "", "null", "None"):
+            execute_horizon = self.action_chunk_size
+        self.execute_horizon = int(execute_horizon)
+        if self.execute_horizon <= 0:
+            raise ValueError(f"execute_horizon must be positive, got {self.execute_horizon}.")
+        if self.execute_horizon > self.action_chunk_size:
+            raise ValueError(
+                f"execute_horizon={self.execute_horizon} exceeds action_chunk_size={self.action_chunk_size}."
+            )
+        self.unnorm_key = self.model_cfg.get("unnorm_key", "arx_x5")
+        if self.unnorm_key in (None, "", "null", "None", "auto"):
+            self.unnorm_key = None
         self.use_ddim = bool(self.model_cfg.get("use_ddim", True))
         self.num_ddim_steps = int(self.model_cfg.get("num_ddim_steps", 10))
         self.image_size = tuple(self.model_cfg.get("image_size", [224, 224]))
@@ -117,7 +129,8 @@ class Model(ModelTemplate):
 
         print(
             f"[starVLA] connected to StarVLA server, action_dim={self.action_dim}, "
-            f"chunk={self.action_chunk_size}, action_order=xpolicy, metadata={server_meta}"
+            f"chunk={self.action_chunk_size}, execute_horizon={self.execute_horizon}, "
+            f"action_order=xpolicy, metadata={server_meta}"
         )
 
     def _convert_obs(self, observation: dict[str, Any]) -> dict[str, Any]:
@@ -148,6 +161,12 @@ class Model(ModelTemplate):
                 self.robot_action_dim_info,
                 source_type="obs",
             ).astype(np.float32)
+            if state.ndim == 1:
+                state = state[None, :]
+            if state.ndim != 2 or state.shape[-1] != self.action_dim:
+                raise ValueError(
+                    f"Expected state shape (T, {self.action_dim}), got {state.shape}."
+                )
             converted_obs["state"] = state
 
         return converted_obs
@@ -171,8 +190,9 @@ class Model(ModelTemplate):
             "do_sample": False,
             "use_ddim": self.use_ddim,
             "num_ddim_steps": self.num_ddim_steps,
-            "unnorm_key": self.unnorm_key,
         }
+        if self.unnorm_key is not None:
+            vla_input["unnorm_key"] = self.unnorm_key
         response = self.client.predict_action(vla_input)
         if not response.get("ok", False):
             raise RuntimeError(f"StarVLA inference failed: {response.get('error', response)}")
@@ -181,11 +201,11 @@ class Model(ModelTemplate):
     def _next_action_vector(self, env_idx: int) -> np.ndarray:
         step = self.step_by_env.get(env_idx, 0)
         chunk = self.action_chunks_by_env.get(env_idx)
-        if chunk is None or step % self.action_chunk_size == 0:
+        if chunk is None or step % self.execute_horizon == 0:
             chunk = self._infer_chunk(env_idx)
             self.action_chunks_by_env[env_idx] = chunk
 
-        action_idx = min(step % self.action_chunk_size, len(chunk) - 1)
+        action_idx = min(step % self.execute_horizon, len(chunk) - 1)
         self.step_by_env[env_idx] = step + 1
         action = np.asarray(chunk[action_idx], dtype=np.float32)
         if action.shape[-1] != self.action_dim:

--- a/policy/starVLA/runtime_config.py
+++ b/policy/starVLA/runtime_config.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+_AUTO_VALUES = {None, "", "auto", "none", "null"}
+
+
+def _parse_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, int) and value in (0, 1):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    raise ValueError(f"Expected a boolean value, got {value!r}.")
+
+
+def _checkpoint_run_dir(checkpoint_path: str | Path) -> Path:
+    path = Path(checkpoint_path).expanduser()
+    if path.is_dir():
+        return path.parent if path.name in {"checkpoints", "final_model"} else path
+    if path.parent.name in {"checkpoints", "final_model"}:
+        return path.parent.parent
+    return path.parent
+
+
+def _read_include_state(config_path: Path) -> bool | None:
+    if not config_path.is_file():
+        return None
+    with config_path.open("r", encoding="utf-8") as stream:
+        config = yaml.safe_load(stream) or {}
+    try:
+        value = config["datasets"]["vla_data"]["include_state"]
+    except (KeyError, TypeError):
+        return None
+    return _parse_bool(value)
+
+
+def resolve_include_state(value: Any, checkpoint_path: str | Path | None) -> bool:
+    """Resolve state input from an override or checkpoint-side configuration."""
+
+    normalized = value.strip().lower() if isinstance(value, str) else value
+    if normalized not in _AUTO_VALUES:
+        return _parse_bool(value)
+    if checkpoint_path in (None, "", "null", "None"):
+        return False
+
+    run_dir = _checkpoint_run_dir(checkpoint_path)
+    for name in ("config.yaml", "config.full.yaml"):
+        include_state = _read_include_state(run_dir / name)
+        if include_state is not None:
+            return include_state
+    return False

--- a/policy/starVLA/setup_eval_policy_server.sh
+++ b/policy/starVLA/setup_eval_policy_server.sh
@@ -100,7 +100,7 @@ checkpoint_path="$(realpath "${checkpoint_path}")"
 echo "[SERVER] resolved StarVLA checkpoint: ${checkpoint_path}"
 starvla_server_port=$(bash "${UTILS_DIR}/get_free_port.sh")
 starvla_server_host="127.0.0.1"
-starvla_include_state="${STARVLA_INCLUDE_STATE:-False}"
+starvla_include_state="${STARVLA_INCLUDE_STATE:-auto}"
 starvla_unnorm_key="${STARVLA_UNNORM_KEY:-arx_x5}"
 starvla_execute_horizon="${STARVLA_EXECUTE_HORIZON:-16}"
 starvla_image_size="${STARVLA_IMAGE_SIZE:-[224,224]}"

--- a/policy/starVLA/setup_eval_policy_server.sh
+++ b/policy/starVLA/setup_eval_policy_server.sh
@@ -100,6 +100,10 @@ checkpoint_path="$(realpath "${checkpoint_path}")"
 echo "[SERVER] resolved StarVLA checkpoint: ${checkpoint_path}"
 starvla_server_port=$(bash "${UTILS_DIR}/get_free_port.sh")
 starvla_server_host="127.0.0.1"
+starvla_include_state="${STARVLA_INCLUDE_STATE:-False}"
+starvla_unnorm_key="${STARVLA_UNNORM_KEY:-arx_x5}"
+starvla_execute_horizon="${STARVLA_EXECUTE_HORIZON:-16}"
+starvla_image_size="${STARVLA_IMAGE_SIZE:-[224,224]}"
 
 cleanup() {
     if [[ -n "${STARVLA_SERVER_PID:-}" ]]; then
@@ -110,6 +114,7 @@ cleanup() {
 trap cleanup EXIT
 
 echo "[SERVER] policy=${policy_name}, task=${task_name}, policy_server_port=${policy_server_port}, starvla_port=${starvla_server_port}"
+echo "[SERVER] starVLA overrides: include_state=${starvla_include_state}, unnorm_key=${starvla_unnorm_key}, execute_horizon=${starvla_execute_horizon}, image_size=${starvla_image_size}"
 
 source "$(conda info --base)/etc/profile.d/conda.sh"
 conda activate "${policy_conda_env}"
@@ -144,6 +149,10 @@ python "${XPL_ROOT}/setup_policy_server.py" \
         policy_name="${policy_name}" \
         action_type="${action_type}" \
         action_dim="${action_dim}" \
+        include_state="${starvla_include_state}" \
+        unnorm_key="${starvla_unnorm_key}" \
+        execute_horizon="${starvla_execute_horizon}" \
+        image_size="${starvla_image_size}" \
         starvla_root="${STARVLA_ROOT}" \
         starvla_server_host="${starvla_server_host}" \
         starvla_server_port="${starvla_server_port}"

--- a/policy/starVLA/source_starvla/deployment/model_server/policy_norm_processor.py
+++ b/policy/starVLA/source_starvla/deployment/model_server/policy_norm_processor.py
@@ -218,23 +218,19 @@ def _build_dataset_metadata(
     state_combined = stats_for_key.get("state", {})
 
     action_stats, action_meta = _split_combined(action_combined, action_keys, action_key_dims)
-    state_stats, state_meta = _split_combined(state_combined, state_keys, state_key_dims)
 
-    # Pydantic accepts dict input with field validators
+    statistics: Dict[str, Any] = {"action": action_stats}
+    modalities: Dict[str, Any] = {"video": {}, "action": action_meta}
+    if state_combined:
+        state_stats, state_meta = _split_combined(state_combined, state_keys, state_key_dims)
+        statistics["state"] = state_stats
+        modalities["state"] = state_meta
+
     return DatasetMetadata.model_validate(
         {
-            "statistics": {
-                "state": state_stats,
-                "action": action_stats,
-            },
-            "modalities": {
-                "video": {},
-                "state": state_meta,
-                "action": action_meta,
-            },
-            "embodiment_tag": embodiment_tag.value
-            if hasattr(embodiment_tag, "value")
-            else embodiment_tag,
+            "statistics": statistics,
+            "modalities": modalities,
+            "embodiment_tag": embodiment_tag.value if hasattr(embodiment_tag, "value") else embodiment_tag,
         }
     )
 
@@ -351,7 +347,57 @@ class PolicyNormProcessor:
         return self._transform
 
     # ------------------------------------------------------------------
-    # Inverse path (model output → env action)
+    # Forward path (env state -> model input)
+    # ------------------------------------------------------------------
+    def apply_state(self, state: np.ndarray) -> np.ndarray:
+        """Normalize proprioceptive state using the training-time pipeline.
+
+        Args:
+            state: shape ``(T, D)`` or ``(D,)`` where
+                ``D == sum(state_key_dims.values())``.
+
+        Returns:
+            State with the same rank as the input, normalized in the format
+            expected by the framework at training time.
+        """
+        if not self._state_keys:
+            return np.asarray(state, dtype=np.float32)
+
+        # MessagePack/websocket decoders may return a read-only NumPy view.
+        # Training transforms convert slices to tensors, so keep this buffer
+        # writable to avoid undefined behavior in PyTorch.
+        state_arr = np.array(state, dtype=np.float32, copy=True)
+        original_ndim = state_arr.ndim
+        if state_arr.ndim == 1:
+            state_arr = state_arr[None, :]
+        if state_arr.ndim != 2:
+            raise ValueError(f"Expected state shape (T, D) or (D,), got {state_arr.shape}")
+
+        data: Dict[str, np.ndarray] = {}
+        cursor = 0
+        for full_key in self._state_keys:
+            dim_k = self._state_key_dims.get(full_key, 1)
+            data[full_key] = state_arr[..., cursor : cursor + dim_k]
+            cursor += dim_k
+
+        if cursor != state_arr.shape[-1]:
+            raise ValueError(
+                f"Sum of per-key dims ({cursor}) != state_dim ({state_arr.shape[-1]}). "
+                f"state_keys={self._state_keys}, state_key_dims={self._state_key_dims}"
+            )
+
+        out = self._transform.apply(data)
+        parts: List[np.ndarray] = []
+        for full_key in self._state_keys:
+            v = out[full_key]
+            if isinstance(v, torch.Tensor):
+                v = v.detach().cpu().numpy()
+            parts.append(np.asarray(v, dtype=np.float32))
+        normalized = np.concatenate(parts, axis=-1)
+        return normalized[0] if original_ndim == 1 else normalized
+
+    # ------------------------------------------------------------------
+    # Inverse path (model output -> env action)
     # ------------------------------------------------------------------
     def unapply_actions(self, normalized_actions: np.ndarray) -> np.ndarray:
         """Invert action normalization using the training-time pipeline.

--- a/policy/starVLA/source_starvla/deployment/model_server/policy_wrapper.py
+++ b/policy/starVLA/source_starvla/deployment/model_server/policy_wrapper.py
@@ -123,6 +123,18 @@ class PolicyServerWrapper:
             base["state_keys"] = proc.state_keys
         return base
 
+    @staticmethod
+    def _normalize_example_states(
+        examples: List[dict], proc: PolicyNormProcessor
+    ) -> List[dict]:
+        normalized_examples = []
+        for example in examples:
+            normalized = dict(example)
+            if "state" in normalized and normalized["state"] is not None:
+                normalized["state"] = proc.apply_state(normalized["state"])
+            normalized_examples.append(normalized)
+        return normalized_examples
+
     def predict_action(
         self,
         examples: List[dict],
@@ -152,7 +164,8 @@ class PolicyServerWrapper:
                 )
         proc = self._get_processor(effective_key)
 
-        out = self._framework.predict_action(examples=examples, **kwargs)
+        model_examples = self._normalize_example_states(examples, proc)
+        out = self._framework.predict_action(examples=model_examples, **kwargs)
         normalized = np.asarray(out["normalized_actions"])  # (B, T, D)
 
         unnorm = np.stack(

--- a/policy/starVLA/source_starvla/examples/XPolicyLab/train_files/data_registry/data_config.py
+++ b/policy/starVLA/source_starvla/examples/XPolicyLab/train_files/data_registry/data_config.py
@@ -117,8 +117,15 @@ class XPolicyArxX5DataConfig:
         )
 
 
+class RoboDojoArxX5H50Q99DataConfig(XPolicyArxX5DataConfig):
+    """RoboDojo ARX X5 runtime schema for 50-step action chunks."""
+
+    action_indices = list(range(50))
+
+
 ROBOT_TYPE_CONFIG_MAP = {
     "xpolicylab_arx_x5": XPolicyArxX5DataConfig(),
+    "robodojo_arx_x5_h50_q99": RoboDojoArxX5H50Q99DataConfig(),
 }
 
 ROBOT_TYPE_TO_EMBODIMENT_TAG = {}
@@ -138,6 +145,12 @@ DATASET_NAMED_MIXTURES = {
     ],
     "xpolicylab_stack_bowls_arx_x5_50": [
         ("arx_x5", 1.0, "xpolicylab_arx_x5"),
+    ],
+    "robodojo_arx_x5_h50_q99": [
+        ("RoboDojo_lerobot_v21_video", 1.0, "robodojo_arx_x5_h50_q99"),
+    ],
+    "robodojo_v21_all_h50_q99": [
+        ("RoboDojo_lerobot_v21_video", 1.0, "robodojo_arx_x5_h50_q99"),
     ],
 }
 

--- a/policy/starVLA/tests/test_runtime_reproducibility.py
+++ b/policy/starVLA/tests/test_runtime_reproducibility.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import importlib
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+POLICY_DIR = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SOURCE_ROOT = POLICY_DIR / "source_starvla"
+sys.path.insert(0, str(REPO_ROOT))
+sys.path.insert(0, str(SOURCE_ROOT))
+
+try:
+    from XPolicyLab.policy.starVLA.runtime_config import resolve_include_state
+except ImportError:
+    resolve_include_state = None
+
+
+class RuntimeRegistryTest(unittest.TestCase):
+    def test_public_and_legacy_mixtures_share_h50_q99_schema(self):
+        from starVLA.dataloader.gr00t_lerobot.registry import (
+            DATASET_NAMED_MIXTURES,
+            ROBOT_TYPE_CONFIG_MAP,
+        )
+
+        public_type = DATASET_NAMED_MIXTURES["robodojo_arx_x5_h50_q99"][0][2]
+        legacy_type = DATASET_NAMED_MIXTURES["robodojo_v21_all_h50_q99"][0][2]
+
+        self.assertEqual(public_type, "robodojo_arx_x5_h50_q99")
+        self.assertEqual(legacy_type, public_type)
+        config = ROBOT_TYPE_CONFIG_MAP[public_type]
+        self.assertEqual(config.action_indices, list(range(50)))
+        self.assertEqual(sum(config.action_key_dims.values()), 14)
+        self.assertEqual(sum(config.state_key_dims.values()), 14)
+
+
+class IncludeStateResolutionTest(unittest.TestCase):
+    def test_model_import_resolves_runtime_config_with_repo_pythonpath(self):
+        module = importlib.import_module("XPolicyLab.policy.starVLA.model")
+        self.assertTrue(hasattr(module, "Model"))
+
+    def setUp(self):
+        self.assertTrue(
+            callable(resolve_include_state),
+            "runtime_config.resolve_include_state is not implemented",
+        )
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.run_dir = Path(self.temp_dir.name)
+        self.checkpoint = self.run_dir / "checkpoints" / "model.pt"
+        self.checkpoint.parent.mkdir()
+        self.checkpoint.touch()
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _write_yaml(self, name: str, include_state: bool | None):
+        config = {"datasets": {"vla_data": {}}}
+        if include_state is not None:
+            config["datasets"]["vla_data"]["include_state"] = include_state
+        (self.run_dir / name).write_text(yaml.safe_dump(config), encoding="utf-8")
+
+    def test_explicit_value_overrides_checkpoint_config(self):
+        self._write_yaml("config.yaml", True)
+        self.assertFalse(resolve_include_state("false", self.checkpoint))
+        self.assertTrue(resolve_include_state("true", self.checkpoint))
+
+    def test_auto_prefers_config_yaml_then_full_config(self):
+        self._write_yaml("config.yaml", False)
+        self._write_yaml("config.full.yaml", True)
+        self.assertFalse(resolve_include_state("auto", self.checkpoint))
+
+        (self.run_dir / "config.yaml").unlink()
+        self.assertTrue(resolve_include_state("auto", self.checkpoint))
+
+    def test_auto_defaults_to_false_without_checkpoint_setting(self):
+        self._write_yaml("config.yaml", None)
+        self.assertFalse(resolve_include_state("auto", self.checkpoint))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR exposes three StarVLA framework variants through the existing
XPolicyLab/RoboDojo policy interface:

- **starVLA-OFT**: MLP regression action head (`QwenOFT`)
- **starVLA-GR00T**: flow-matching DiT action head (`QwenGR00T`)
- **starVLA-π**: layer-wise cross-DiT flow-matching action head (`QwenPI_v3`)

All variants use the public Qwen3-VL-4B-Instruct visual-language backbone.
Their action-policy components are trained from scratch; Qwen3-VL-4B-Instruct
is the only pretrained backbone initialization. The integration does not
require internal robot data, private demonstrations, hidden VLA pretraining,
or unreleased pretrained policy weights.

The runtime package remains `policy/starVLA`. The three public names are
reporting labels, while the checkpoint configuration selects the registered
StarVLA framework.

## Scope

- Use the RoboDojo ARX X5 normalization key by default.
- Register the public `robodojo_arx_x5_h50_q99` runtime schema and retain
  `robodojo_v21_all_h50_q99` as a checkpoint compatibility alias.
- Resolve `include_state` from checkpoint-side configuration unless explicitly
  overridden at deployment time.
- Normalize proprioceptive state with the checkpoint's training-time transform
  in the vendored StarVLA inference server.
- Validate the optional proprioceptive state shape before inference.
- Allow the predicted action horizon and executed action horizon to differ.
- Expose state, normalization, image-size, and execution-horizon overrides in
  the split policy-server launcher.
- Document the three public framework names and their external runtime
  contract.

No StarVLA training pipeline change, training data, model checkpoint, or
private dependency is included in this PR. Changes under `source_starvla` are
limited to the deployment model server.

## External StarVLA requirements

The vendored runtime implements the following contract. Any separately
installed StarVLA checkout must also:

1. Register `QwenOFT`, `QwenGR00T`, and `QwenPI_v3`, and reconstruct the
   framework selected by checkpoint configuration.
2. Accept three RGB camera observations, a language instruction, and an
   optional 14-dimensional ARX X5 absolute-joint state in left-arm,
   left-gripper, right-arm, right-gripper order.
3. Normalize state with the checkpoint's `arx_x5` statistics before inference.
   The 50-step RoboDojo schema uses q99 normalization for all 14 dimensions,
   including the continuous grippers.
4. Return actions with shape `[batch, horizon, 14]`, unnormalized with the same
   `arx_x5` statistics, and expose `action_chunk_size` in websocket metadata.
5. Produce a 50-action chunk; XPolicyLab executes the first 16 actions before
   requesting a new chunk.

Released checkpoint folders retain `config.yaml`, `config.full.yaml`, and
`dataset_statistics.json` beside `checkpoints/`. These files make state selection
and normalization reproducible without a private runtime registry.

## Related issues

None.

## Type of change

- [x] New policy integration
- [x] Bug fix for train/evaluation consistency
- [x] Documentation
- [ ] Breaking change

## How did you test this change?

Each framework was evaluated end to end on the RoboDojo `build_tower` task
using ten episodes, with proprioceptive state enabled and the ARX X5
normalization statistics used for training.

| Variant | Episodes | Successes | Success rate | Score |
|---|---:|---:|---:|---:|
| starVLA-OFT | 10 | 5 | 50% | 65.0 |
| starVLA-GR00T | 10 | 2 | 20% | 25.0 |
| starVLA-π | 10 | 9 | 90% | 93.0 |

Additional checks:

- Five runtime-registry and checkpoint-configuration unit tests
- Vendored-runtime model-server smoke for `QwenOFT`, `QwenGR00T`, and `QwenPI_v3`
- Full XPolicyLab policy-server smoke resolving `include_state=True` from the checkpoint
- `python -m py_compile policy/starVLA/model.py`
- `bash -n policy/starVLA/setup_eval_policy_server.sh`
- `git diff --check`

## Checklist

- [x] The PR title and commits follow the repository convention.
- [x] The change contains no absolute local paths, private data, or checkpoint.
- [x] The added data registry is a declarative inference schema only; no dataset,
      training executable, or training configuration is included.
- [x] The external StarVLA interface requirements are documented.
- [x] Existing policy adapters are unchanged.
- [x] Debugging artifacts and generated evaluation outputs are excluded.
