### PR TITLE
Add G05 policy adapter

### DIFF
--- a/policy/G05/README.md
+++ b/policy/G05/README.md
@@ -1,0 +1,49 @@
+# G05 RoboDojo Adapter
+
+This adapter integrates the GitHub G0.5 checkout at
+`/efm-nas/efm-nas/group-jt/haoyu.zhang/GalaxeaVLA_github_port` with XPolicyLab. It does not use the vendored
+`policy/GalaxeaVLA/GalaxeaVLA` code.
+
+## Training
+
+Default training uses G0.5 task config:
+
+```bash
+cd /efm-nas/efm-nas/group-jt/haoyu.zhang/external/robodojo/XPolicyLab/policy/G05
+export ROBODOJO_LEROBOT_V30_ROOT=/efm-nas/efm-nas/group-jt/haoyu.zhang/external/robodojo/data/RoboDojo_lerobot_v30_video
+bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3,4,5,6,7
+```
+
+For the GitHub G0.5 launcher, use
+`/efm-nas/efm-nas/group-jt/haoyu.zhang/GalaxeaVLA_github_port/scripts/run/finetune_robodojo_arx_x5_joint.sh`.
+
+## Evaluation
+
+Set `G05_CKPT_PATH` to a G0.5 run directory or `.pt` checkpoint. Debug mode
+validates websocket wiring and action schema without the simulator:
+
+```bash
+cd /efm-nas/efm-nas/group-jt/haoyu.zhang/external/robodojo/XPolicyLab/policy/G05
+export EVAL_ENV_TYPE=debug
+export G05_CKPT_PATH=/path/to/g05/run/or/checkpoints/checkpoint
+bash eval.sh RoboDojo stack_bowls cotrain arx_x5 joint 0 0 0 \
+  /mlplatform/haoyu.zhang/g05_runtime/g05_venv_nas base
+```
+
+For simulator evaluation, unset `EVAL_ENV_TYPE` or set it to `sim` and make
+sure the RoboDojo evaluator-side repo with `env_cfg/`, `scripts/`, `src/`, and
+`task/` is mounted next to `XPolicyLab`.
+
+## Checkpoint
+
+The submitted FM-only RoboDojo ARX X5 joint checkpoint and inference assets are hosted at:
+
+https://huggingface.co/XZHY528/g05
+
+Download and extract `xpolicylab_g05_fm_only_checkpoint_20260724.tar`, then set `G05_CKPT_PATH` to the extracted `XPolicyLab/policy/G05/checkpoints/checkpoint` path before evaluation.
+
+Required sidecars included in the archive:
+
+- `.hydra/config.yaml`
+- `dataset_stats.json`
+- `action_tokenizer.pt`

--- a/policy/G05/__init__.py
+++ b/policy/G05/__init__.py
@@ -1,0 +1,1 @@
+"""G0.5 adapter for XPolicyLab."""

--- a/policy/G05/deploy.py
+++ b/policy/G05/deploy.py
@@ -1,0 +1,44 @@
+def eval_one_episode(TASK_ENV, model_client):
+    model_client.call(func_name="reset")
+
+    while not TASK_ENV.is_episode_end():
+        obs = TASK_ENV.get_obs()
+        model_client.call(func_name="update_obs", obs=obs)
+        actions = model_client.call(func_name="get_action")
+
+        for action_idx, action in enumerate(actions):
+            TASK_ENV.take_action(action)
+
+            if TASK_ENV.is_episode_end() or action_idx + 1 == len(actions):
+                break
+
+            obs = TASK_ENV.get_obs()
+            model_client.call(func_name="update_obs", obs=obs)
+
+
+def eval_one_episode_batch(TASK_ENV, model_client):
+    model_client.call(func_name="reset")
+
+    while not TASK_ENV.is_episode_end():
+        env_idx_list = TASK_ENV.get_running_env_idx_list()
+        obs_list = TASK_ENV.get_obs_batch(env_idx_list)
+        model_client.call(func_name="update_obs_batch", obs=obs_list)
+        actions = model_client.call(func_name="get_action_batch", env_idx_list=env_idx_list)
+
+        chunk_size = len(actions[0])
+        for action_idx in range(chunk_size):
+            current_action_list = [env_actions[action_idx] for env_actions in actions]
+            TASK_ENV.take_action_batch(current_action_list, env_idx_list)
+
+            if TASK_ENV.is_episode_end() or action_idx + 1 == chunk_size:
+                break
+
+            running = set(TASK_ENV.get_running_env_idx_list())
+            active_batch_idx = [i for i, env_idx in enumerate(env_idx_list) if env_idx in running]
+
+            actions = [actions[i] for i in active_batch_idx]
+            env_idx_list = [env_idx_list[i] for i in active_batch_idx]
+            model_client.call(
+                func_name="update_obs_batch",
+                obs=TASK_ENV.get_obs_batch(env_idx_list),
+            )

--- a/policy/G05/deploy.yml
+++ b/policy/G05/deploy.yml
@@ -1,0 +1,21 @@
+policy_name: G05
+protocol: ws
+host: localhost
+port: null
+bench_name: null
+task_name: null
+ckpt_name: null
+env_cfg_type: arx_x5
+seed: null
+action_type: joint
+action_dim: 14
+eval_batch: true
+
+g05_root: /efm-nas/efm-nas/group-jt/haoyu.zhang/GalaxeaVLA_github_port
+ckpt_path: null
+eval_embodiment: robodojo
+action_steps: 16
+frequency: 30
+# The launcher passes action_source=ar or action_source=fm.  The adapter derives
+# matching Hydra flags from that value so one deploy file safely serves both.
+hydra_overrides: []

--- a/policy/G05/eval.sh
+++ b/policy/G05/eval.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bench_name=${1:?bench_name required}
+task_name=${2:?task_name required}
+ckpt_name=${3:?ckpt_name required}
+env_cfg_type=${4:?env_cfg_type required}
+action_type=${5:?action_type required}
+seed=${6:?seed required}
+policy_gpu_id=${7:?policy_gpu_id required}
+env_gpu_id=${8:?env_gpu_id required}
+policy_env=${9:?policy env/python/venv required}
+eval_env_conda_env=${10:?eval env required}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+XPL_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+UTILS_DIR="${XPL_ROOT}/utils"
+
+policy_server_port=$(bash "${UTILS_DIR}/get_free_port.sh")
+policy_server_ip="${POLICY_SERVER_HOST:-localhost}"
+additional_info="ckpt_name=${ckpt_name},action_type=${action_type}"
+
+cleanup() {
+  if [[ -n "${SERVER_PID:-}" ]]; then
+    kill "${SERVER_PID}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+echo "[MAIN] start G05 policy server on ${policy_server_ip}:${policy_server_port}"
+bash "${SCRIPT_DIR}/setup_eval_policy_server.sh" \
+  "${bench_name}" "${task_name}" "${ckpt_name}" "${env_cfg_type}" "${action_type}" "${seed}" \
+  "${policy_gpu_id}" "${policy_env}" "${policy_server_port}" "${policy_server_ip}" &
+SERVER_PID=$!
+
+bash "${UTILS_DIR}/wait_for_policy_server.sh" "${policy_server_ip}" "${policy_server_port}" "${SERVER_PID}" "G05 policy server" 1200
+
+echo "[MAIN] start env client"
+bash "${SCRIPT_DIR}/setup_eval_env_client.sh" \
+  "${bench_name}" "${task_name}" "${ckpt_name}" "${env_cfg_type}" "${action_type}" "${seed}" \
+  "${env_gpu_id}" "${eval_env_conda_env}" "${additional_info}" "${policy_server_port}" "${policy_server_ip}"
+
+echo "[MAIN] eval finished"

--- a/policy/G05/model.py
+++ b/policy/G05/model.py
@@ -1,0 +1,344 @@
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from XPolicyLab.model_template import ModelTemplate
+from XPolicyLab.utils.process_data import (
+    decode_image_bit,
+    get_batch_size,
+    get_robot_action_dim_info,
+    pack_robot_state,
+    unpack_robot_state,
+)
+
+
+IMAGE_CANDIDATES = {
+    "cam_high": ("cam_high", "cam_head", "cam_third_view"),
+    "cam_left_wrist": ("cam_left_wrist",),
+    "cam_right_wrist": ("cam_right_wrist",),
+}
+BATCH_OBSERVATIONS_KEY = "__xpolicylab_batch_observations__"
+
+
+class Model(ModelTemplate):
+    def __init__(self, model_cfg):
+        self.model_cfg = model_cfg
+        self.action_type = str(model_cfg.get("action_type", "joint"))
+        if self.action_type != "joint":
+            raise ValueError(f"G0.5 RoboDojo adapter supports action_type=joint, got {self.action_type}")
+
+        self.env_cfg_type = str(model_cfg.get("env_cfg_type", "arx_x5"))
+        self.embodiment_type = str(model_cfg.get("eval_embodiment") or "robodojo")
+        self.action_steps = int(model_cfg.get("action_steps") or 16)
+        self.default_frequency = float(model_cfg.get("frequency") or 30)
+        self.inference_batch_size = max(
+            1,
+            int(
+                model_cfg.get("inference_batch_size")
+                or os.environ.get("ROBODOJO_G05_INFERENCE_BATCH_SIZE", "8")
+            ),
+        )
+
+        self.robot_action_dim_info = self._resolve_robot_action_dim_info()
+        self.batch_size = self._resolve_batch_size()
+        self._obs: dict[str, Any] | None = None
+        self._obs_batch: list[dict[str, Any]] = []
+
+        g05_root = Path(
+            model_cfg.get("g05_root")
+            or os.environ.get("G05_ROOT")
+            or "/efm-nas/efm-nas/group-jt/haoyu.zhang/GalaxeaVLA_github_port"
+        ).expanduser().resolve()
+        if not g05_root.exists():
+            raise FileNotFoundError(f"G0.5 repo not found: {g05_root}")
+        for path in (g05_root / "src", g05_root):
+            if str(path) not in sys.path:
+                sys.path.insert(0, str(path))
+        os.chdir(g05_root)
+
+        ckpt_path = self._resolve_ckpt_path(model_cfg)
+        requested_action_source = str(
+            model_cfg.get("action_source")
+            or os.environ.get("ROBODOJO_G05_ACTION_SOURCE")
+            or "auto"
+        )
+        hydra_overrides = [
+            str(item)
+            for item in (model_cfg.get("hydra_overrides") or [])
+            if not str(item).startswith(
+                (
+                    "model.model_arch.discrete_action=",
+                    "model.model_arch.continuous_action=",
+                    "model.model_arch.return_continuous_action=",
+                    "model.processor.discrete_action=",
+                )
+            )
+        ]
+        if requested_action_source == "ar":
+            hydra_overrides.extend(
+                [
+                    "model.model_arch.discrete_action=true",
+                    "model.model_arch.continuous_action=false",
+                    "model.model_arch.return_continuous_action=true",
+                    "model.processor.discrete_action=true",
+                ]
+            )
+        elif requested_action_source == "fm":
+            hydra_overrides.extend(
+                [
+                    "model.model_arch.discrete_action=false",
+                    "model.model_arch.continuous_action=true",
+                    "model.model_arch.return_continuous_action=true",
+                    "model.processor.discrete_action=false",
+                ]
+            )
+        hydra_overrides.append(f"eval_embodiment={self.embodiment_type}")
+
+        from g05.models.g05.inferencer import PolicyInferencer
+        from g05.utils.checkpoint.ckpt_utils import find_run_dir, load_config_from_run_dir
+        from g05.utils.eval.eval_utils import filter_embodiment
+        from scripts.serve_policy import build_obs_dict, setup
+
+        run_dir = find_run_dir(str(ckpt_path))
+        cfg = load_config_from_run_dir(run_dir, str(ckpt_path), hydra_overrides)
+        if self.embodiment_type and "embodiment_datasets" in cfg.data:
+            filter_embodiment(cfg, self.embodiment_type)
+
+        self._build_obs_dict = build_obs_dict
+        device = "cuda"
+        self.policy, self.processor = setup(cfg, device=device)
+        self.discrete_action = bool(
+            getattr(self.policy, "discrete_action", cfg.model.model_arch.discrete_action)
+        )
+        self.continuous_action = bool(
+            getattr(self.policy, "continuous_action", cfg.model.model_arch.continuous_action)
+        )
+        if requested_action_source == "auto":
+            # Preserve existing joint/FM behavior while making AR-only explicit.
+            requested_action_source = "fm" if self.continuous_action else "ar"
+        if requested_action_source == "fm" and not self.continuous_action:
+            raise ValueError("G05 action_source=fm requested but checkpoint has continuous_action=false")
+        if requested_action_source == "ar" and not self.discrete_action:
+            raise ValueError("G05 action_source=ar requested but checkpoint has discrete_action=false")
+        if requested_action_source not in {"ar", "fm", "both"}:
+            raise ValueError(f"Unsupported G05 action_source={requested_action_source!r}")
+        self.action_source = requested_action_source
+        self.inferencer = PolicyInferencer(
+            self.policy,
+            self.processor,
+            device=device,
+            action_source=self.action_source,
+        )
+        print(
+            f"[G05] loaded ckpt={ckpt_path} run_dir={run_dir} "
+            f"embodiment={self.embodiment_type} "
+            f"inference_batch_size={self.inference_batch_size} "
+            f"action_source={self.action_source} "
+            f"discrete_action={self.discrete_action} "
+            f"continuous_action={self.continuous_action}"
+        )
+
+    def _resolve_robot_action_dim_info(self) -> dict[str, list[int]]:
+        try:
+            return get_robot_action_dim_info(self.env_cfg_type)
+        except Exception as exc:
+            if self.env_cfg_type == "arx_x5":
+                print(f"[G05] using built-in arx_x5 dims because env_cfg lookup failed: {exc}")
+                return {"arm_dim": [6, 6], "ee_dim": [1, 1]}
+            raise
+
+    def _resolve_batch_size(self) -> int:
+        try:
+            return int(get_batch_size(self.env_cfg_type))
+        except Exception:
+            return 1
+
+    def _resolve_ckpt_path(self, model_cfg) -> Path:
+        raw = model_cfg.get("ckpt_path") or os.environ.get("G05_CKPT_PATH")
+        if not raw:
+            raise FileNotFoundError("Set ckpt_path in deploy.yml/overrides or export G05_CKPT_PATH")
+
+        path = Path(str(raw)).expanduser()
+        if not path.is_absolute():
+            path = Path(__file__).resolve().parent / path
+        path = path.resolve()
+
+        if path.is_file():
+            return path
+        if not path.is_dir():
+            raise FileNotFoundError(f"G0.5 checkpoint path not found: {path}")
+
+        candidates = [path / "last.pt"]
+        candidates.extend(sorted((path / "checkpoints").glob("step_*.pt"), key=_step_sort_key))
+        candidates.extend(sorted(path.glob("**/step_*.pt"), key=_step_sort_key))
+        candidates.extend(path.glob("model_state_dict.pt"))
+        for candidate in reversed(candidates):
+            if candidate.is_file():
+                return candidate.resolve()
+        raise FileNotFoundError(f"No G0.5 .pt checkpoint found under {path}")
+
+    def update_obs(self, obs):
+        if isinstance(obs, dict) and BATCH_OBSERVATIONS_KEY in obs:
+            observations = obs[BATCH_OBSERVATIONS_KEY]
+            if not isinstance(observations, (list, tuple)):
+                raise TypeError(f"{BATCH_OBSERVATIONS_KEY} must contain a list")
+            self._obs = None
+            self._obs_batch = list(observations)
+            return
+        self._obs = obs
+        self._obs_batch = []
+
+    def update_obs_batch(self, obs_list):
+        self._obs_batch = list(obs_list)
+
+    def get_action(self):
+        if self._obs_batch:
+            return self.get_action_batch()
+        if self._obs is None:
+            raise RuntimeError("update_obs must be called before get_action")
+        return self._predict_chunk(self._obs)
+
+    def get_action_batch(self, env_idx_list=None):
+        obs_list = self._obs_batch
+        if env_idx_list is not None:
+            obs_list = obs_list[: len(env_idx_list)]
+        if not obs_list:
+            size = len(env_idx_list) if env_idx_list is not None else self.batch_size
+            return [self.get_action() for _ in range(size)]
+        return self._predict_chunks(obs_list)
+
+    def reset(self):
+        self._obs = None
+        self._obs_batch = []
+
+    def _predict_chunk(self, obs: dict[str, Any]) -> list[dict[str, np.ndarray]]:
+        return self._predict_chunks([obs])[0]
+
+    def _predict_chunks(
+        self, observations: list[dict[str, Any]]
+    ) -> list[list[dict[str, np.ndarray]]]:
+        obs_dicts = [
+            self._build_obs_dict(self._to_g05_raw_obs(obs), self.processor)
+            for obs in observations
+        ]
+        batch_size = max(1, int(getattr(self, "inference_batch_size", len(obs_dicts))))
+        actions = []
+        for start in range(0, len(obs_dicts), batch_size):
+            actions.extend(self.inferencer.infer(obs_dicts[start : start + batch_size]))
+        return [self._format_action_chunk(action) for action in actions]
+
+    def _format_action_chunk(self, action) -> list[dict[str, np.ndarray]]:
+        action.pop("_cot_text", None)
+        action.pop("_absent_keys", None)
+
+        parts = {key: _to_horizon_array(value) for key, value in action.items()}
+        horizon = min(self.action_steps, min(arr.shape[0] for arr in parts.values()))
+        result = []
+        for t in range(horizon):
+            packed = np.concatenate(
+                [
+                    parts["left_arm"][t],
+                    parts["left_gripper"][t],
+                    parts["right_arm"][t],
+                    parts["right_gripper"][t],
+                ],
+                axis=-1,
+            ).astype(np.float32)
+            result.append(
+                unpack_robot_state(
+                    packed,
+                    self.action_type,
+                    self.robot_action_dim_info,
+                    source_type="obs",
+                )
+            )
+        return result
+
+    def _to_g05_raw_obs(self, obs: dict[str, Any]) -> dict[str, Any]:
+        packed_state = pack_robot_state(
+            obs,
+            self.action_type,
+            self.robot_action_dim_info,
+            source_type="obs",
+            state_type="state",
+        ).astype(np.float32)
+
+        instruction = obs.get("instruction", obs.get("instructions", self.model_cfg.get("task_name", "")))
+        if isinstance(instruction, (list, tuple)):
+            instruction = instruction[0] if instruction else ""
+
+        additional_info = obs.get("additional_info") or {}
+        return {
+            "images": {
+                "cam_high": self._extract_image(obs, "cam_high"),
+                "cam_left_wrist": self._extract_image(obs, "cam_left_wrist"),
+                "cam_right_wrist": self._extract_image(obs, "cam_right_wrist"),
+            },
+            "state": {
+                "left_arm": packed_state[0:6],
+                "left_gripper": packed_state[6:7],
+                "right_arm": packed_state[7:13],
+                "right_gripper": packed_state[13:14],
+            },
+            "task": str(instruction),
+            "frequency": float(additional_info.get("frequency", self.default_frequency)),
+            "embodiment_type": self.embodiment_type,
+        }
+
+    def _extract_image(self, obs: dict[str, Any], g05_key: str) -> np.ndarray:
+        vision = obs.get("vision") or {}
+        for candidate in IMAGE_CANDIDATES[g05_key]:
+            view = vision.get(candidate)
+            if isinstance(view, dict):
+                if "color" in view:
+                    return _as_chw_uint8(view["color"])
+                if "colors" in view:
+                    return _as_chw_uint8(view["colors"])
+            elif view is not None:
+                return _as_chw_uint8(view)
+        raise KeyError(f"Missing image for {g05_key}; tried {IMAGE_CANDIDATES[g05_key]}")
+
+
+def _step_sort_key(path: Path) -> int:
+    stem = path.stem
+    if stem.startswith("step_"):
+        try:
+            return int(stem.split("_", 1)[1])
+        except ValueError:
+            return -1
+    return -1
+
+
+def _as_chw_uint8(value) -> np.ndarray:
+    if not isinstance(value, np.ndarray):
+        value = decode_image_bit(value)
+    arr = np.asarray(value)
+    if arr.ndim == 4:
+        arr = arr[0]
+    if arr.ndim != 3:
+        raise ValueError(f"image must be 3D, got shape={arr.shape}")
+    if arr.shape[0] == 3:
+        chw = arr
+    elif arr.shape[-1] == 3:
+        chw = np.transpose(arr, (2, 0, 1))
+    else:
+        raise ValueError(f"image must have 3 channels, got shape={arr.shape}")
+    return np.ascontiguousarray(chw.astype(np.uint8, copy=False))
+
+
+def _to_horizon_array(value) -> np.ndarray:
+    if hasattr(value, "detach"):
+        value = value.detach().cpu().numpy()
+    arr = np.asarray(value, dtype=np.float32)
+    if arr.ndim == 3:
+        arr = arr[0]
+    if arr.ndim == 1:
+        arr = arr[None, :]
+    if arr.ndim != 2:
+        raise ValueError(f"action part must be [H,D], got shape={arr.shape}")
+    return arr

--- a/policy/G05/setup_eval_env_client.sh
+++ b/policy/G05/setup_eval_env_client.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bench_name=${1:?bench_name required}
+task_name=${2:?task_name required}
+ckpt_name=${3:?ckpt_name required}
+env_cfg_type=${4:?env_cfg_type required}
+action_type=${5:?action_type required}
+seed=${6:?seed required}
+env_gpu_id=${7:?env_gpu_id required}
+eval_env_conda_env=${8:?eval_env_conda_env required}
+additional_info=${9:-}
+policy_server_port=${10:?policy_server_port required}
+policy_server_ip=${11:-localhost}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+XPL_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BENCH_ROOT="$(cd "${XPL_ROOT}/.." && pwd)"
+UTILS_DIR="${XPL_ROOT}/utils"
+policy_name="$(basename "${SCRIPT_DIR}")"
+yaml_file="${SCRIPT_DIR}/deploy.yml"
+
+echo "[CLIENT] policy=${policy_name}, task=${task_name}, server=${policy_server_ip}:${policy_server_port}"
+
+bash "${UTILS_DIR}/setup_env_client.sh" \
+  "${UTILS_DIR}" \
+  "${yaml_file}" \
+  "${eval_env_conda_env}" \
+  "${policy_server_port}" \
+  "${bench_name}" \
+  "${task_name}" \
+  "${env_cfg_type}" \
+  "${policy_name}" \
+  "${additional_info}" \
+  "${BENCH_ROOT}" \
+  "${seed}" \
+  "${env_gpu_id}" \
+  "${policy_server_ip}"

--- a/policy/G05/setup_eval_policy_server.sh
+++ b/policy/G05/setup_eval_policy_server.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bench_name=${1:?bench_name required}
+task_name=${2:?task_name required}
+ckpt_name=${3:?ckpt_name required}
+env_cfg_type=${4:?env_cfg_type required}
+action_type=${5:?action_type required}
+seed=${6:?seed required}
+policy_gpu_id=${7:?policy_gpu_id required}
+policy_env=${8:-base}
+policy_server_port=${9:?policy_server_port required}
+policy_server_host=${10:-localhost}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+XPL_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+BENCH_ROOT="$(cd "${XPL_ROOT}/.." && pwd)"
+UTILS_DIR="${XPL_ROOT}/utils"
+policy_name="$(basename "${SCRIPT_DIR}")"
+yaml_file="${SCRIPT_DIR}/deploy.yml"
+
+G05_ROOT="${G05_ROOT:-/efm-nas/efm-nas/group-jt/haoyu.zhang/GalaxeaVLA_github_port}"
+PYTHON_BIN="${G05_PYTHON:-}"
+if [[ -z "${PYTHON_BIN}" ]]; then
+  if [[ "${policy_env}" == /* && -x "${policy_env}/bin/python" ]]; then
+    PYTHON_BIN="${policy_env}/bin/python"
+  elif [[ -x "${policy_env}" ]]; then
+    PYTHON_BIN="${policy_env}"
+  elif [[ -x "/mlplatform/haoyu.zhang/g05_runtime/g05_venv_nas/bin/python" ]]; then
+    PYTHON_BIN="/mlplatform/haoyu.zhang/g05_runtime/g05_venv_nas/bin/python"
+  else
+    PYTHON_BIN="$(command -v python3)"
+  fi
+fi
+
+resolve_ckpt_path() {
+  local raw="$1"
+  local run_dir_name="${bench_name}-${ckpt_name}-${env_cfg_type}-${action_type}-${seed}"
+  local candidates=()
+
+  if [[ -n "${G05_CKPT_PATH:-}" ]]; then
+    candidates+=("${G05_CKPT_PATH}")
+  fi
+  if [[ "${raw}" == /* ]]; then
+    candidates+=("${raw}")
+  elif [[ "${raw}" == */* ]]; then
+    candidates+=("${SCRIPT_DIR}/${raw}")
+  else
+    candidates+=(
+      "${SCRIPT_DIR}/checkpoints/${run_dir_name}"
+      "${SCRIPT_DIR}/checkpoints/${raw}"
+      "${G05_ROOT}/outputs/${run_dir_name}"
+      "/efm-nas/efm-nas/group-jt/haoyu.zhang/experiments_compare/results/robodojo/g05/github_robodojo_arx_x5_joint/robodojo_arx_x5_joint/${run_dir_name}"
+    )
+  fi
+
+  local candidate
+  for candidate in "${candidates[@]}"; do
+    if [[ -f "${candidate}" || -d "${candidate}" ]]; then
+      realpath "${candidate}"
+      return 0
+    fi
+  done
+
+  echo "No checkpoint found. Set G05_CKPT_PATH to a G0.5 .pt file or run directory." >&2
+  echo "Tried:" >&2
+  printf '  %s\n' "${candidates[@]}" >&2
+  return 1
+}
+
+if [[ "${action_type}" != "joint" ]]; then
+  echo "G05 adapter currently supports action_type=joint, got ${action_type}" >&2
+  exit 2
+fi
+
+if [[ ! -d "${G05_ROOT}" ]]; then
+  echo "G0.5 repo not found: ${G05_ROOT}" >&2
+  exit 3
+fi
+
+ckpt_path="$(resolve_ckpt_path "${ckpt_name}")"
+
+if ! action_dim=$(bash "${UTILS_DIR}/get_action_dim.sh" "${BENCH_ROOT}" "${env_cfg_type}" 2>/dev/null); then
+  if [[ "${env_cfg_type}" == "arx_x5" ]]; then
+    action_dim=14
+  else
+    echo "Could not resolve action_dim for ${env_cfg_type}; check ${BENCH_ROOT}/env_cfg." >&2
+    exit 4
+  fi
+fi
+
+echo "[SERVER] policy=${policy_name} task=${task_name} host=${policy_server_host} port=${policy_server_port}"
+echo "[SERVER] python=${PYTHON_BIN}"
+echo "[SERVER] g05_root=${G05_ROOT}"
+echo "[SERVER] ckpt_path=${ckpt_path}"
+echo "[SERVER] action_dim=${action_dim}"
+
+cd "${G05_ROOT}"
+
+exec env \
+  PYTHONUNBUFFERED=1 \
+  PYTHONWARNINGS=ignore::UserWarning \
+  CUDA_VISIBLE_DEVICES="${policy_gpu_id}" \
+  PYTHONPATH="${G05_ROOT}/src:${G05_ROOT}:${BENCH_ROOT}:${XPL_ROOT}:${PYTHONPATH:-}" \
+  "${PYTHON_BIN}" -u "${XPL_ROOT}/setup_policy_server.py" \
+    --config_path "${yaml_file}" \
+    --overrides \
+      host="${policy_server_host}" \
+      port="${policy_server_port}" \
+      bench_name="${bench_name}" \
+      task_name="${task_name}" \
+      ckpt_name="${ckpt_name}" \
+      env_cfg_type="${env_cfg_type}" \
+      seed="${seed}" \
+      policy_name="${policy_name}" \
+      action_type="${action_type}" \
+      action_dim="${action_dim}" \
+      ckpt_path="${ckpt_path}" \
+      g05_root="${G05_ROOT}"


### PR DESCRIPTION
# Add G05 policy adapter

## Summary

This PR adds the G05 policy adapter for XPolicyLab/RoboDojo evaluation.

Included files:

- `policy/G05/model.py`
- `policy/G05/deploy.py`
- `policy/G05/deploy.yml`
- `policy/G05/eval.sh`
- `policy/G05/setup_eval_policy_server.sh`
- `policy/G05/setup_eval_env_client.sh`
- `policy/G05/README.md`
- `policy/G05/__init__.py`

## Checkpoint and inference assets

Checkpoint and required inference assets are hosted separately on Hugging Face:

https://huggingface.co/XZHY528/g05

The archive contains:

- `XPolicyLab/policy/G05/checkpoints/checkpoint`
- `XPolicyLab/policy/G05/.hydra/config.yaml`
- `XPolicyLab/policy/G05/dataset_stats.json`
- `XPolicyLab/policy/G05/action_tokenizer.pt`

## Notes

- The adapter uses websocket protocol (`protocol: ws`).
- The adapter supports RoboDojo `arx_x5` with `joint` action type.
- The submitted checkpoint is G05 FM-only for RoboDojo ARX X5 joint evaluation.
- Large model assets are intentionally not committed to the GitHub PR.

## Validation

- `python3 -m py_compile policy/G05/model.py policy/G05/deploy.py`
- Full RoboDojo 3-seed local evaluation was run separately; official leaderboard submission should use RoboDojo cloud evaluation/verification.
