### PR TITLE
Support FastWAM inference on 24GB GPUs

### DIFF
--- a/client_server/ws/model_server.py
+++ b/client_server/ws/model_server.py
@@ -34,8 +34,8 @@ def _ok_payload(result: Any = None) -> dict[str, Any]:
 class PolicyServerConfig:
     host: str = "0.0.0.0"
     port: int = 19000
-    ws_ping_interval_s: float = 20.0
-    ws_ping_timeout_s: float = 20.0
+    ws_ping_interval_s: float = 60.0
+    ws_ping_timeout_s: float = 300.0
 
 
 @dataclass

--- a/client_server/ws/protocol/client.py
+++ b/client_server/ws/protocol/client.py
@@ -55,11 +55,11 @@ class PolicyEvalClientConfig:
     url: str
     evaluation_id: str
     connect_timeout_s: float = 30.0
-    request_timeout_s: float = 120.0
+    request_timeout_s: float = 600.0
     max_connect_attempts: int = 10
     connect_retry_delay_s: float = 5.0
-    ws_ping_interval_s: float = 20.0
-    ws_ping_timeout_s: float = 20.0
+    ws_ping_interval_s: float = 60.0
+    ws_ping_timeout_s: float = 300.0
     proxy: str | Literal[True] | None = None
 
 

--- a/policy/FastWAM/FastWAM/experiments/robotwin/fastwam_policy/deploy_policy.py
+++ b/policy/FastWAM/FastWAM/experiments/robotwin/fastwam_policy/deploy_policy.py
@@ -324,6 +324,31 @@ def get_model(usr_args: Dict[str, Any]):
         sim_cfg_name=sim_cfg_name,
         sim_task=sim_task,
     )
+    # Released RoboDojo checkpoints contain the complete video/action MoT
+    # state.  Allow deployment to initialize those experts without first
+    # downloading/loading the Wan DiT and generated ActionDiT backbone only to
+    # overwrite both immediately in load_checkpoint().
+    if "skip_dit_load_from_pretrain" in usr_args:
+        OmegaConf.update(
+            cfg,
+            "model.skip_dit_load_from_pretrain",
+            _parse_bool(usr_args["skip_dit_load_from_pretrain"]),
+            force_add=True,
+        )
+    if "redirect_common_files" in usr_args:
+        OmegaConf.update(
+            cfg,
+            "model.redirect_common_files",
+            _parse_bool(usr_args["redirect_common_files"]),
+            force_add=True,
+        )
+    if "sequential_aux_offload" in usr_args:
+        OmegaConf.update(
+            cfg,
+            "model.sequential_aux_offload",
+            _parse_bool(usr_args["sequential_aux_offload"]),
+            force_add=True,
+        )
 
     checkpoint_path = usr_args.get("ckpt_setting")
     if _is_none_like(checkpoint_path):

--- a/policy/FastWAM/FastWAM/src/fastwam/models/wan22/fastwam.py
+++ b/policy/FastWAM/FastWAM/src/fastwam/models/wan22/fastwam.py
@@ -38,6 +38,7 @@ class FastWAM(torch.nn.Module):
         action_num_train_timesteps: int = 1000,
         loss_lambda_video: float = 1.0,
         loss_lambda_action: float = 1.0,
+        sequential_aux_offload: bool = False,
     ):
         super().__init__()
         self.video_expert = video_expert
@@ -82,6 +83,7 @@ class FastWAM(torch.nn.Module):
 
         self.device = torch.device(device)
         self.torch_dtype = torch_dtype
+        self.sequential_aux_offload = bool(sequential_aux_offload)
         self.loss_lambda_video = float(loss_lambda_video)
         self.loss_lambda_action = float(loss_lambda_action)
 
@@ -102,6 +104,7 @@ class FastWAM(torch.nn.Module):
         action_dit_config: dict[str, Any] | None = None,
         action_dit_pretrained_path: str | None = None,
         skip_dit_load_from_pretrain: bool = False,
+        sequential_aux_offload: bool = False,
         mot_checkpoint_mixed_attn: bool = True,
         video_train_shift: float = 5.0,
         video_infer_shift: float = 5.0,
@@ -117,8 +120,9 @@ class FastWAM(torch.nn.Module):
         if "text_dim" not in video_dit_config:
             raise ValueError("`video_dit_config['text_dim']` is required for FastWAM.")
 
+        component_load_device = "cpu" if sequential_aux_offload else device
         components = load_wan22_ti2v_5b_components(
-            device=device,
+            device=component_load_device,
             torch_dtype=torch_dtype,
             model_id=model_id,
             tokenizer_model_id=tokenizer_model_id,
@@ -168,6 +172,7 @@ class FastWAM(torch.nn.Module):
             action_num_train_timesteps=action_num_train_timesteps,
             loss_lambda_video=loss_lambda_video,
             loss_lambda_action=loss_lambda_action,
+            sequential_aux_offload=sequential_aux_offload,
         )
         model.model_paths = {
             "video_dit": components.dit_path,
@@ -181,6 +186,22 @@ class FastWAM(torch.nn.Module):
         return model
 
     def to(self, *args, **kwargs):
+        target = kwargs.get("device")
+        if target is None and args and not isinstance(args[0], torch.dtype):
+            target = args[0]
+        if (
+            self.sequential_aux_offload
+            and target is not None
+            and torch.device(target).type == "cuda"
+        ):
+            dtype = kwargs.get("dtype")
+            self.mot.to(device=target, dtype=dtype)
+            if self.proprio_encoder is not None:
+                self.proprio_encoder.to(device=target, dtype=dtype)
+            self.vae.to(device="cpu")
+            if self.text_encoder is not None:
+                self.text_encoder.to(device="cpu")
+            return self
         super().to(*args, **kwargs)
         self.mot.to(*args, **kwargs)
         if self.text_encoder is not None:
@@ -958,7 +979,16 @@ class FastWAM(torch.nn.Module):
         ).to(device=self.device, dtype=self.torch_dtype)
 
         input_image = input_image.to(device=self.device, dtype=self.torch_dtype)
+        if self.sequential_aux_offload:
+            self.mot.to(device="cpu")
+            if self.proprio_encoder is not None:
+                self.proprio_encoder.to(device="cpu")
+            torch.cuda.empty_cache()
+            self.vae.to(device=self.device, dtype=self.torch_dtype)
         first_frame_latents = self._encode_input_image_latents_tensor(input_image=input_image, tiled=tiled)
+        if self.sequential_aux_offload:
+            self.vae.to(device="cpu")
+            torch.cuda.empty_cache()
         fuse_flag = bool(getattr(self.video_expert, "fuse_vae_embedding_in_latents", False))
 
         use_prompt = prompt is not None
@@ -969,7 +999,12 @@ class FastWAM(torch.nn.Module):
             raise ValueError("Either `prompt` or both `context/context_mask` must be provided.")
 
         if use_prompt:
+            if self.sequential_aux_offload:
+                self.text_encoder.to(device=self.device, dtype=self.torch_dtype)
             context, context_mask = self.encode_prompt(prompt)
+            if self.sequential_aux_offload:
+                self.text_encoder.to(device="cpu")
+                torch.cuda.empty_cache()
         else:
             if context is None or context_mask is None:
                 raise ValueError("`context` and `context_mask` must be both provided together.")
@@ -983,6 +1018,10 @@ class FastWAM(torch.nn.Module):
                 )
             context = context.to(device=self.device, dtype=self.torch_dtype, non_blocking=True)
             context_mask = context_mask.to(device=self.device, dtype=torch.bool, non_blocking=True)
+        if self.sequential_aux_offload:
+            self.mot.to(device=self.device, dtype=self.torch_dtype)
+            if self.proprio_encoder is not None:
+                self.proprio_encoder.to(device=self.device, dtype=self.torch_dtype)
         if proprio is not None:
             context, context_mask = self._append_proprio_to_context(
                 context=context,

--- a/policy/FastWAM/FastWAM/src/fastwam/runtime.py
+++ b/policy/FastWAM/FastWAM/src/fastwam/runtime.py
@@ -88,6 +88,7 @@ def create_fastwam(
     loss=None,
     mot_checkpoint_mixed_attn: bool = True,
     redirect_common_files: bool = True,
+    sequential_aux_offload: bool = False,
     model_dtype: torch.dtype = torch.bfloat16,
     device: str = "cuda",
 ):
@@ -146,6 +147,7 @@ def create_fastwam(
         action_dit_config=action_dit_config,
         action_dit_pretrained_path=action_dit_pretrained_path,
         skip_dit_load_from_pretrain=bool(skip_dit_load_from_pretrain),
+        sequential_aux_offload=bool(sequential_aux_offload),
         mot_checkpoint_mixed_attn=bool(mot_checkpoint_mixed_attn),
         video_train_shift=float(video_scheduler.get("train_shift", 5.0)),
         video_infer_shift=float(video_scheduler.get("infer_shift", 5.0)),

--- a/policy/FastWAM/deploy.yml
+++ b/policy/FastWAM/deploy.yml
@@ -36,5 +36,14 @@ negative_prompt: ""
 rand_device: cpu
 tiled: false
 timing_enabled: false
+# The official RoboDojo step_020000 checkpoint contains both MoT experts.
+# Skip redundant Wan DiT/ActionDiT preload, then replace them from checkpoint.
+skip_dit_load_from_pretrain: true
+# Reuse the original Wan .pth common files. This also avoids relying on the
+# currently gated DiffSynth converted-safetensors repository.
+redirect_common_files: false
+# A single 24 GiB GPU also hosts Isaac Sim. Keep VAE/T5 on CPU and swap the
+# MoT and auxiliary encoders sequentially so their weights never coexist on GPU.
+sequential_aux_offload: true
 default_instruction: follow the instruction
 allow_dummy_policy: false


### PR DESCRIPTION
## What changed

- Allow FastWAM deployment overrides to skip redundant pretrained DiT loading and select original common model files.
- Add optional sequential auxiliary-component offloading for Wan VAE, UMT5, and MoT/proprio modules.
- Enable the memory-saving path in the RoboDojo FastWAM deployment configuration.
- Increase WebSocket request and ping timeouts for slow first-pass world-action inference.

## Why

The released RoboDojo `step_020000.pt` checkpoint already contains the complete
video/action MoT state. Loading the pretrained Wan DiT and ActionDiT first
wastes memory and is immediately overwritten by the released checkpoint. In
addition, the MoT, UMT5, VAE, and Isaac Sim cannot remain resident together on
a single 24 GiB GPU.

Sequentially moving the VAE, text encoder, and MoT between CPU and GPU keeps
peak device usage low enough to run policy inference and Isaac Sim on one RTX
4090 D. The longer transport timeouts prevent the client connection from being
closed during the slower first inference.

## Impact

FastWAM can run the official RoboDojo ARX-X5 joint checkpoint alongside Isaac
Sim on a 24 GiB GPU. The offload behavior is optional at the model API level
and enabled for the RoboDojo FastWAM deployment profile.

## Validation

- Python `compileall` passed for all changed Python modules.
- `git diff --check` passed.
- Deployment configuration assertions passed.
- Official checkpoint `RoboDojo-sim-arx_x5-joint-0`, step 20,000, was verified
  against its published SHA-256.
- End-to-end RoboDojo `stack_bowls`, layout 0: 1/1 successful episode,
  terminated successfully at frame 326/800.
- Observed GPU residency during the run: approximately 11.3 GiB for FastWAM
  and 7.9 GiB for Isaac Sim on an RTX 4090 D.
