### PR TITLE
fix default train config

### DIFF
--- a/policy/Abot_M0/abot_m0/train.sh
+++ b/policy/Abot_M0/abot_m0/train.sh
@@ -54,7 +54,7 @@ export GRADIENT_ACCUMULATION_STEPS="${ABOT_GRAD_ACC:-1}"
 export NUM_WORKERS="${ABOT_NUM_WORKERS:-0}"
 # RoboDojo_sim_v21_video_abot is AV1 encoded, so torchvision_av is required; decord cannot decode it
 export VIDEO_BACKEND="${ABOT_VIDEO_BACKEND:-torchvision_av}"
-export MAX_TRAIN_STEPS="${ABOT_MAX_TRAIN_STEPS:-150000}"
+export MAX_TRAIN_STEPS="${ABOT_MAX_TRAIN_STEPS:-100000}"
 export SAVE_INTERVAL="${ABOT_SAVE_INTERVAL:-10000}"
 
 mkdir -p "${ckpt_dir}"

--- a/policy/Dexbotic_DM0/train.sh
+++ b/policy/Dexbotic_DM0/train.sh
@@ -15,7 +15,7 @@ gpu_id=$6
 
 # Batch config (single source of truth):
 #   global_batch = DM0_BATCH_SIZE * NUM_GPUS * DM0_GRAD_ACCUM
-export DM0_GLOBAL_BATCH_SIZE="${DM0_GLOBAL_BATCH_SIZE:-64}"
+export DM0_GLOBAL_BATCH_SIZE="${DM0_GLOBAL_BATCH_SIZE:-32}"
 export DM0_BATCH_SIZE="${DM0_BATCH_SIZE:-4}"
 export DM0_MAX_STEPS="${DM0_MAX_STEPS:-100000}"
 

--- a/policy/GR00T_N17/train.sh
+++ b/policy/GR00T_N17/train.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# GLOBAL_BATCH_SIZE=640 MAX_STEPS=60000 bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3,4,5,6,7
+# GLOBAL_BATCH_SIZE=640 MAX_STEPS=100000 bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3,4,5,6,7
 
 set -euo pipefail
 
@@ -67,7 +67,7 @@ fi
 
 mkdir -p "${output_dir}"
 
-MAX_STEPS="${MAX_STEPS:-60000}"
+MAX_STEPS="${MAX_STEPS:-100000}"
 SAVE_STEPS="${SAVE_STEPS:-1000}"
 GLOBAL_BATCH_SIZE="${GLOBAL_BATCH_SIZE:-640}"
 USE_WANDB="${USE_WANDB:-0}"

--- a/policy/OpenVLA_OFT/openvla_oft/scripts/finetune.sh
+++ b/policy/OpenVLA_OFT/openvla_oft/scripts/finetune.sh
@@ -55,7 +55,7 @@ torchrun --standalone --nnodes 1 --nproc-per-node "${NUM_GPUS}" vla-scripts/fine
   --use_film True \
   --num_images_in_input 3 \
   --use_proprio True \
-  --batch_size 2 \
+  --batch_size 16 \
   --learning_rate 5e-4 \
   --num_steps_before_decay 50000 \
   --max_steps "${MAX_STEPS}" \

--- a/policy/SmolVLA/train.sh
+++ b/policy/SmolVLA/train.sh
@@ -43,7 +43,7 @@ lerobot-train \
   --output_dir=${OUTPUT_DIR} \
   --job_name=${JOB_NAME} \
   --policy.device=cuda \
-  --batch_size=64 \
+  --batch_size=512 \
   --steps=100000 \
   --save_freq=10000 \
   --log_freq=10 \

--- a/policy/TinyVLA/tinyvla/scripts/train.sh
+++ b/policy/TinyVLA/tinyvla/scripts/train.sh
@@ -37,7 +37,7 @@ deepspeed --master_port 29600 --num_gpus=8 --num_nodes=1 ./train_tinyvla.py \
   --group_by_modality_length False \
   --bf16 True \
   --output_dir $OUTPUT \
-  --max_steps 10000 \
+  --max_steps 60000 \
   --per_device_train_batch_size 32 \
   --gradient_accumulation_steps 1 \
   --save_strategy "steps" \

--- a/policy/TinyVLA/train.sh
+++ b/policy/TinyVLA/train.sh
@@ -64,7 +64,7 @@ deepspeed --master_port 29600 --include "localhost:${gpu_id}" "${POLICY_DIR}/tra
   --xpl_env_cfg_type                "${env_cfg_type}" \
   --xpl_action_type                 "${action_type}" \
   --xpl_seed                        "${seed}" \
-  --max_steps                       10000 \
+  --max_steps                       60000 \
   --per_device_train_batch_size     32 \
   --save_steps                      1000 \
   --save_total_limit                50 \

--- a/policy/X_VLA/train.sh
+++ b/policy/X_VLA/train.sh
@@ -33,7 +33,7 @@ accelerate launch \
     --train_metas_path "${meta_path}" \
     --learning_rate 1e-4 \
     --learning_coef 0.1 \
-    --iters 30000 \
+    --iters 100000 \
     --freeze_steps 1000 \
     --warmup_steps 2000 \
     --batch_size 32 \

--- a/policy/X_VLA/xvla/meta.json
+++ b/policy/X_VLA/xvla/meta.json
@@ -4,6 +4,6 @@
     "language_instruction_fallback_keys": ["instruction", "language_instruction", "task_name", "task"],
     "observation_key": ["vision/cam_head/colors"],
     "datalist": [
-        "/mnt/nfs/niantian/RoboDojo_env/data/RoboDojo_real"
+        "/path/to/RoboDojo_data"
     ]
 }

--- a/policy/Xiaomi_Robotics_0/process_data.sh
+++ b/policy/Xiaomi_Robotics_0/process_data.sh
@@ -160,7 +160,7 @@ python "${POLICY_DIR}/scripts/generate_data_config.py" \
   "${converted_data_root}/action_stats.json" \
   "${XR0_ROOT}/configs/data/${data_config_name}.yaml" \
   --json_dir "${converted_data_root}/json" \
-  --batch_size "${XR0_BATCH_SIZE:-16}"
+  --batch_size "${XR0_BATCH_SIZE:-32}"
 
 if [[ -d "${converted_data_root}/.raw_staging" ]]; then
   rm -rf "${converted_data_root}/.raw_staging"

--- a/policy/Xiaomi_Robotics_0/scripts/generate_data_config.py
+++ b/policy/Xiaomi_Robotics_0/scripts/generate_data_config.py
@@ -13,7 +13,7 @@ def main() -> None:
     parser.add_argument("stats_path", type=Path)
     parser.add_argument("output_path", type=Path)
     parser.add_argument("--json_dir", type=Path, required=True)
-    parser.add_argument("--batch_size", type=int, default=16)
+    parser.add_argument("--batch_size", type=int, default=32)
     args = parser.parse_args()
 
     stats = json.loads(args.stats_path.read_text(encoding="utf-8"))

--- a/policy/Xiaomi_Robotics_0/train.sh
+++ b/policy/Xiaomi_Robotics_0/train.sh
@@ -79,5 +79,5 @@ bash scripts/train.sh \
   "trainer.seed=${seed}" \
   "model.params.model.pretrained=${pretrained_path}" \
   "model.params.model.async_train=${XR0_ASYNC_TRAIN:-false}" \
-  "trainer.max_steps=${XR0_MAX_STEPS:-30000}" \
+  "trainer.max_steps=${XR0_MAX_STEPS:-100000}" \
   "trainer.save_interval=${XR0_SAVE_INTERVAL:-5000}"

--- a/policy/Xiaomi_Robotics_0/xiaomi_robotics_0/xr0/assets/config.py
+++ b/policy/Xiaomi_Robotics_0/xiaomi_robotics_0/xr0/assets/config.py
@@ -1,9 +1,9 @@
 data = dict(
     params=dict(
-        max_steps=30000,
+        max_steps=100000,
         train_datasets=dict(
             action_length=30,
-            batch_size=16,
+            batch_size=32,
             mean=[
                 [
                     0.003474651137366891,
@@ -2082,7 +2082,7 @@ trainer = dict(
     exp_name='robodojo_sim',
     gradient_clip_algorithm='norm',
     gradient_clip_val=1.0,
-    max_steps=30000,
+    max_steps=100000,
     num_nodes=1,
     optimizer=dict(
         params=dict(betas=[
@@ -2098,7 +2098,7 @@ trainer = dict(
         params=dict(
             max_lr=0.0001,
             min_lr=5e-07,
-            num_training_steps=30000,
+            num_training_steps=100000,
             num_warmup_steps=2000,
             warmup_lr_start=5e-07),
         type='mibot.utils.cosine_warmup.get_cosine_schedule_with_warmup'),

--- a/policy/Xiaomi_Robotics_0/xiaomi_robotics_0/xr0/configs/trainer/deepspeed.yaml
+++ b/policy/Xiaomi_Robotics_0/xiaomi_robotics_0/xr0/configs/trainer/deepspeed.yaml
@@ -33,7 +33,7 @@ trainer:
 
   # Training settings
   seed: 42
-  max_steps: 30000
+  max_steps: 100000
   val_check_interval: 2000
   save_interval: 5000
   accumulate_grad_batches: 1


### PR DESCRIPTION
<!-- Policy submission PR — see CONTRIBUTING.md for the full standard.
     For non-policy changes, delete the sections that do not apply. -->

## Policy
- Name / paper / upstream repo:
- Supported: bench_name=..., env_cfg_type=..., action_type=...
- Training support: full | eval-only (training release ETA: ...)

## Components
- [ ] install.sh
- [ ] model.py (+ __init__.py)
- [ ] deploy.yml (protocol: ws, policy_name matches the directory)
- [ ] deploy.py aligned with demo_policy (or divergence explained)
- [ ] eval.sh + setup_eval_policy_server.sh + setup_eval_env_client.sh
- [ ] process_data.sh / train.sh (or eval-only, declared above)
- [ ] policy README with install / data / train / eval commands

## Testing
- [ ] bash -n + py_compile pass
- [ ] EVAL_ENV_TYPE=debug closed loop passes (paste the log tail)
- [ ] Simulator eval: task=..., success=... (if available)

## Checkpoint (required for leaderboard evaluation)
<download script, Hugging Face or ModelScope preferred>

## Limitations / notes
...
