### PR TITLE
Align AHA-WAM training and inference with upstream

### DIFF
--- a/policy/AHA_WAM/AHAWAM/README.md
+++ b/policy/AHA_WAM/AHAWAM/README.md
@@ -12,9 +12,9 @@ baseline model variants.
   observation/action metadata, normalization stats, and text embedding cache.
 - `configs/model/ahawam.yaml`: AHA-WAM model, ActionDiT, scheduler, and loss
   defaults.
-- `configs/task/robodojo_local_history_updated_kv_prior_only_16.yaml`: the
-  training task matching the prepared RoboDojo data and 14-D joint/qpos action
-  format.
+- `configs/task/robodojo_ahawam_finetune_32_kv_xpolicy.yaml`: portable
+  XPolicyLab counterpart of the official 32-epoch RoboDojo AHA-WAM finetune
+  recipe, matching the prepared data and 14-D joint/qpos action format.
 - `scripts/train.py` and `scripts/train_zero1.sh`: Hydra and Accelerate
   launchers.
 - `src/ahawam`: package code for datasets, Wan2.2/AHA-WAM modules, and trainer.
@@ -59,12 +59,18 @@ Useful overrides:
 export AHA_WAM_TRAIN_DATASET_DIR=/path/to/RoboDojo_lerobot_v21_video
 export AHA_WAM_OUTPUT_ROOT=/path/to/checkpoints
 export AHA_WAM_INIT_CHECKPOINT=/path/to/step_xxxxxx.pt
+export AHA_WAM_RESUME=/path/to/states_5000
 export AHA_WAM_TRAIN_SEED=1
 export DIFFSYNTH_MODEL_BASE_PATH=/path/to/dualWAM/checkpoints
 ```
 
 The wrapper maps seed `0` to training seed `1`, matching the upstream AHAWAM
 requirement that seeds are positive `uint32` values.
+
+For result-level reproduction, `AHA_WAM_RESUME` must point to the same
+official-compatible training-state checkpoint used by the reference finetune.
+Leaving it unset runs the aligned recipe from the configured base weights, which
+is not numerically equivalent to the official resumed run.
 
 ### Smoke Test
 

--- a/policy/AHA_WAM/AHAWAM/configs/task/robodojo_ahawam_finetune_32_kv_xpolicy.yaml
+++ b/policy/AHA_WAM/AHAWAM/configs/task/robodojo_ahawam_finetune_32_kv_xpolicy.yaml
@@ -1,0 +1,52 @@
+# @package _global_
+
+# Portable XPolicyLab counterpart of the official
+# `robodojo_ahawam_finetune_32_kv` recipe. Dataset/checkpoint paths are supplied
+# by policy/AHA_WAM/train.sh instead of being hard-coded to the authors' hosts.
+defaults:
+  - override /data: robodojo
+  - override /model: ahawam
+  - _self_
+
+batch_size: 8
+num_workers: 6
+history_aware_batching: true
+
+model:
+  mot_checkpoint_mixed_attn: true
+  action_obs_downsample_factor: 1
+  chunk_kv_editor_num_queries: 32
+  num_history_frames: 6
+  action_video_read_mode: current_only
+  video_rope_frame_stride: ${data.train.action_video_freq_ratio}
+  loss:
+    lambda_action_prior: 1.0
+
+output_dir: ${oc.env:AHA_WAM_OUTPUT_ROOT,./outputs}/${hydra:runtime.choices.task}-${oc.env:RUN_ID,manual}
+
+wandb:
+  enabled: true
+  workspace: null
+  project: ahawam
+  name: robodojo_ahawam_finetune
+  group: null
+  mode: offline
+
+lr_scheduler_type: cosine
+learning_rate: 1e-5
+num_epochs: 32
+max_steps: 30000
+log_every: 10
+save_every: 2500
+eval_every: 500
+
+gradient_accumulation_steps: 2
+weight_decay: 1e-2
+manual_gc_every: 50
+
+# Supply the official-compatible state directory through AHA_WAM_RESUME when
+# reproducing a finetune run. Keep paths null here so config composition remains
+# portable and an accidental stale host path can never be loaded.
+resume: null
+init_checkpoint: null
+resume_dataloader_state: false

--- a/policy/AHA_WAM/AHAWAM/configs/task/robodojo_local_history_updated_kv_prior_only.yaml
+++ b/policy/AHA_WAM/AHAWAM/configs/task/robodojo_local_history_updated_kv_prior_only.yaml
@@ -16,9 +16,6 @@ model:
   num_history_frames: 6
   action_video_read_mode: current_only
   video_rope_frame_stride: ${data.train.action_video_freq_ratio}
-  detach_history_kv_during_training: true
-  prepend_episode_first_frame: true
-  prior_only_training: true
   loss:
     lambda_action_prior: 1.0
 

--- a/policy/AHA_WAM/AHAWAM/configs/task/robodojo_local_history_updated_kv_prior_only_16.yaml
+++ b/policy/AHA_WAM/AHAWAM/configs/task/robodojo_local_history_updated_kv_prior_only_16.yaml
@@ -15,7 +15,6 @@ model:
   chunk_kv_editor_num_queries: 32
   num_history_frames: 6
   action_video_read_mode: current_only
-  prepend_episode_first_frame: true
   video_rope_frame_stride: ${data.train.action_video_freq_ratio}
   loss:
     lambda_action_prior: 1.0

--- a/policy/AHA_WAM/AHAWAM/configs/task/robodojo_local_history_updated_kv_prior_only_nokv.yaml
+++ b/policy/AHA_WAM/AHAWAM/configs/task/robodojo_local_history_updated_kv_prior_only_nokv.yaml
@@ -16,9 +16,6 @@ model:
   num_history_frames: 0
   action_video_read_mode: current_only
   video_rope_frame_stride: ${data.train.action_video_freq_ratio}
-  detach_history_kv_during_training: true
-  prepend_episode_first_frame: false
-  prior_only_training: true
   loss:
     lambda_action_prior: 1.0
 

--- a/policy/AHA_WAM/AHAWAM/configs/train.yaml
+++ b/policy/AHA_WAM/AHAWAM/configs/train.yaml
@@ -28,10 +28,14 @@ gradient_accumulation_steps: 1
 mixed_precision: "bf16" # one of: [no, fp16, bf16]
 seed: 42
 max_grad_norm: 1.0
+manual_gc_every: 1
 weight_decay: 0.0
 freeze_video_dit: false
 resume: null
 init_checkpoint: null
+# Set false when the dataset/config changed: model, optimizer, scheduler, and
+# random states are restored, while sampler progress restarts from epoch 0.
+resume_dataloader_state: true
 # Cross-config resume: total batch size (batch_size * num_gpus * grad_accum)
 # of the source run. Steps are converted proportionally when this differs
 # from the current global batch size.

--- a/policy/AHA_WAM/AHAWAM/scripts/train_zero1.sh
+++ b/policy/AHA_WAM/AHAWAM/scripts/train_zero1.sh
@@ -28,7 +28,7 @@ MAIN_PROCESS_IP="${MASTER_ADDR:-127.0.0.1}"
 MAIN_PROCESS_PORT="${MASTER_PORT:-29500}"
 DEEPSPEED_HOSTFILE="${DEEPSPEED_HOSTFILE:-${DS_HOSTFILE:-${HOSTFILE:-}}}"
 
-DEFAULT_TASK="robodojo_local_history_updated_kv_prior_only_16"
+DEFAULT_TASK="robodojo_ahawam_finetune_32_kv_xpolicy"
 DEFAULT_MODEL="ahawam"
 is_integer() {
   [[ "${1}" =~ ^[0-9]+$ ]]

--- a/policy/AHA_WAM/AHAWAM/src/ahawam/datasets/lerobot/base_lerobot_dataset.py
+++ b/policy/AHA_WAM/AHAWAM/src/ahawam/datasets/lerobot/base_lerobot_dataset.py
@@ -3,7 +3,11 @@ import numpy as np
 from pathlib import Path
 from typing import List, Literal, Dict, Optional, Any, DefaultDict
 from tqdm import tqdm
-from .lerobot.lerobot_dataset import LeRobotDatasetMetadata, MultiLeRobotDataset
+from .lerobot.lerobot_dataset import (
+    LeRobotDatasetMetadata,
+    MultiLeRobotDataset,
+    get_lerobot_repo_id_for_root,
+)
 
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import traceback
@@ -13,6 +17,32 @@ from .processors.base_processor import BaseProcessor
 logger = get_logger(__name__)
 
 MAX_GETITEM_ATTEMPT = 5
+
+
+def expand_lerobot_dataset_dirs(dataset_dirs: List[str]) -> List[str]:
+    """Accept dataset leaves or a parent directory containing several datasets."""
+    expanded: List[str] = []
+    seen = set()
+    for dataset_dir in dataset_dirs:
+        root = Path(dataset_dir)
+        if (root / "meta" / "info.json").is_file():
+            candidates = [root]
+        elif root.is_dir():
+            candidates = sorted(
+                path.parent.parent
+                for path in root.rglob("meta/info.json")
+                if path.is_file()
+            )
+        else:
+            candidates = [root]
+
+        for candidate in candidates:
+            candidate_str = str(candidate)
+            if candidate_str not in seen:
+                expanded.append(candidate_str)
+                seen.add(candidate_str)
+    return expanded
+
 
 class BaseLerobotDataset(torch.utils.data.Dataset):
     def __init__(
@@ -34,22 +64,23 @@ class BaseLerobotDataset(torch.utils.data.Dataset):
         # sampling
         global_sample_stride: int = 1,
         image_sample_indices: Optional[List[int]] = None,
+        skip_missing_episode_files: bool = False,
     ):
         assert len(dataset_dirs) > 0, "At least one dataset directory is required"
         assert past_action_size == 0
         assert past_obs_size == 0
         assert action_size == obs_size - 1, "In this dataset, action_size should be obs_size - 1"
         
-        self.dataset_dirs = dataset_dirs
+        self.dataset_dirs = expand_lerobot_dataset_dirs(dataset_dirs)
         self.shape_meta = shape_meta
         self.action_size = action_size
         self.past_action_size = past_action_size
         self.obs_size = obs_size
         self.processor = None  # Will be set externally
         metas = []
-        for ds_dir in dataset_dirs:
+        for ds_dir in self.dataset_dirs:
             ds_root = Path(ds_dir)
-            repo_id = ds_dir
+            repo_id = get_lerobot_repo_id_for_root(ds_dir, ds_root)
             meta = LeRobotDatasetMetadata(repo_id=repo_id, root=ds_root)
             metas.append(meta)
 
@@ -66,6 +97,7 @@ class BaseLerobotDataset(torch.utils.data.Dataset):
 
         self.val_set_proportion = val_set_proportion
         self.is_training_set = is_training_set
+        self.skip_missing_episode_files = bool(skip_missing_episode_files)
 
         self.image_meta = shape_meta["images"]
         self.state_meta = shape_meta["state"]
@@ -74,7 +106,10 @@ class BaseLerobotDataset(torch.utils.data.Dataset):
         delta_timestamps = {}
         for meta in self.image_meta:
             key = meta["key"]
-            meta["lerobot_key"] = f"observation.images.{key}" if key != "default" else "observation.images"
+            meta["lerobot_key"] = meta.get(
+                "lerobot_key",
+                f"observation.images.{key}" if key != "default" else "observation.images",
+            )
             image_steps = (
                 self.image_sample_indices
                 if self.image_sample_indices is not None
@@ -86,20 +121,30 @@ class BaseLerobotDataset(torch.utils.data.Dataset):
         
         for meta in self.state_meta:
             key = meta["key"]
-            meta["lerobot_key"] = f"observation.state.{key}" if key != "default" else "observation.state"
+            meta["lerobot_key"] = meta.get(
+                "lerobot_key",
+                f"observation.state.{key}" if key != "default" else "observation.state",
+            )
             delta_timestamps[meta["lerobot_key"]] = [
                 (t * global_sample_stride) / fps for t in range(-past_obs_size, -past_obs_size + obs_size)
             ]
         
         for meta in self.action_meta:
             key = meta["key"]
-            meta["lerobot_key"] = f"action.{key}" if key != "default" else "action"
+            meta["lerobot_key"] = meta.get(
+                "lerobot_key",
+                f"action.{key}" if key != "default" else "action",
+            )
             delta_timestamps[meta["lerobot_key"]] = [(t * global_sample_stride) / fps for t in range(-past_action_size, -past_action_size + action_size)]
 
         episodes = {}
         if val_set_proportion < 1e-6:
             for meta in metas:
-                episodes.update({meta.repo_id: list(range(meta.total_episodes))})
+                episode_indices = self._filter_available_episodes(
+                    meta, list(range(meta.total_episodes))
+                )
+                if episode_indices:
+                    episodes.update({meta.repo_id: episode_indices})
         else:
             for meta in metas:
                 split_idx = int(meta.total_episodes * (1 - val_set_proportion))
@@ -108,9 +153,27 @@ class BaseLerobotDataset(torch.utils.data.Dataset):
                 rng = np.random.default_rng(seed)
                 rng.shuffle(episode_indices)
                 if self.is_training_set:
-                    episodes.update({meta.repo_id: [episode_indices[i] for i in range(split_idx)]})
+                    selected_episodes = [episode_indices[i] for i in range(split_idx)]
                 else:
-                    episodes.update({meta.repo_id: [episode_indices[i] for i in range(split_idx, meta.total_episodes)]})
+                    selected_episodes = [
+                        episode_indices[i]
+                        for i in range(split_idx, meta.total_episodes)
+                    ]
+                selected_episodes = self._filter_available_episodes(
+                    meta, selected_episodes
+                )
+                if selected_episodes:
+                    episodes.update({meta.repo_id: selected_episodes})
+
+        if not episodes:
+            raise RuntimeError(
+                "No valid episodes remain after applying train/val split"
+                + (
+                    " and missing-file filtering."
+                    if self.skip_missing_episode_files
+                    else "."
+                )
+            )
 
         self.multi_dataset = MultiLeRobotDataset(
             dataset_dirs=self.dataset_dirs,
@@ -133,6 +196,37 @@ class BaseLerobotDataset(torch.utils.data.Dataset):
             "from": torch.cat([dataset["from"] for dataset in episode_data_index]),
             "to": torch.cat([dataset["to"] for dataset in episode_data_index]),
         }
+
+    def _filter_available_episodes(
+        self,
+        meta: LeRobotDatasetMetadata,
+        episode_indices: list[int],
+    ) -> list[int]:
+        if not self.skip_missing_episode_files:
+            return episode_indices
+
+        valid = []
+        missing_count = 0
+        for ep_idx in episode_indices:
+            required_files = [meta.root / meta.get_data_file_path(ep_idx)]
+            required_files.extend(
+                meta.root / meta.get_video_file_path(ep_idx, video_key)
+                for video_key in meta.video_keys
+            )
+            if all(path.is_file() for path in required_files):
+                valid.append(ep_idx)
+            else:
+                missing_count += 1
+
+        if missing_count:
+            logger.warning(
+                "Skipping %d/%d episodes in %s because referenced parquet/video "
+                "files are missing.",
+                missing_count,
+                len(episode_indices),
+                meta.root,
+            )
+        return valid
 
     def _get_action(self, meta, lerobot_sample) -> torch.Tensor:
         key, lerobot_key, raw_shape = meta["key"], meta["lerobot_key"], meta["raw_shape"]

--- a/policy/AHA_WAM/AHAWAM/src/ahawam/datasets/lerobot/lerobot/datasets/utils.py
+++ b/policy/AHA_WAM/AHAWAM/src/ahawam/datasets/lerobot/lerobot/datasets/utils.py
@@ -30,6 +30,7 @@ import datasets
 import jsonlines
 import numpy as np
 import packaging.version
+import pyarrow.parquet as pq
 import torch
 from datasets.table import embed_table_storage
 from huggingface_hub import DatasetCard, DatasetCardData, HfApi
@@ -55,6 +56,9 @@ EPISODES_PATH = "meta/episodes.jsonl"
 STATS_PATH = "meta/stats.json"
 EPISODES_STATS_PATH = "meta/episodes_stats.jsonl"
 TASKS_PATH = "meta/tasks.jsonl"
+TASKS_PARQUET_PATH = "meta/tasks.parquet"
+EPISODES_PARQUET_GLOB = "meta/episodes/chunk-*/file-*.parquet"
+EPISODES_STATS_PARQUET_GLOB = "meta/episodes_stats/chunk-*/file-*.parquet"
 
 ANNOTATION_PATHS = {
     "subtask": "annotations/subtask_annotations.jsonl",
@@ -226,8 +230,31 @@ def write_task(task_index: int, task: dict, local_dir: Path):
 
 
 def load_tasks(local_dir: Path) -> tuple[dict, dict]:
-    tasks = load_jsonlines(local_dir / TASKS_PATH)
-    tasks = {item["task_index"]: item["task"] for item in sorted(tasks, key=lambda x: x["task_index"])}
+    tasks_path = local_dir / TASKS_PATH
+    if not tasks_path.exists():
+        tasks_parquet_path = local_dir / TASKS_PARQUET_PATH
+        if not tasks_parquet_path.exists():
+            raise FileNotFoundError(
+                f"Missing tasks metadata: expected {tasks_path} or {tasks_parquet_path}"
+            )
+        table = pq.read_table(str(tasks_parquet_path))
+        tasks = table.to_pylist()
+    else:
+        tasks = load_jsonlines(tasks_path)
+
+    def _get_task(item: dict):
+        for key in ("task", "name", "description", "__index_level_0__"):
+            if key in item:
+                return item[key]
+        raise KeyError(
+            "Could not find task text in task metadata item. "
+            f"Available keys: {sorted(item.keys())}"
+        )
+
+    tasks = {
+        item["task_index"]: _get_task(item)
+        for item in sorted(tasks, key=lambda x: x["task_index"])
+    }
     task_to_task_index = {task: task_index for task_index, task in tasks.items()}
     return tasks, task_to_task_index
 
@@ -244,7 +271,18 @@ def write_episode(episode: dict, local_dir: Path):
 
 
 def load_episodes(local_dir: Path) -> dict:
-    episodes = load_jsonlines(local_dir / EPISODES_PATH)
+    episodes_path = local_dir / EPISODES_PATH
+    if not episodes_path.exists():
+        parquet_files = sorted(local_dir.glob(EPISODES_PARQUET_GLOB))
+        if not parquet_files:
+            raise FileNotFoundError(
+                f"Missing episodes metadata: expected {episodes_path} or {EPISODES_PARQUET_GLOB}"
+            )
+        episodes = []
+        for parquet_file in parquet_files:
+            episodes.extend(pq.read_table(str(parquet_file)).to_pylist())
+    else:
+        episodes = load_jsonlines(episodes_path)
     return {item["episode_index"]: item for item in sorted(episodes, key=lambda x: x["episode_index"])}
 
 
@@ -256,7 +294,18 @@ def write_episode_stats(episode_index: int, episode_stats: dict, local_dir: Path
 
 
 def load_episodes_stats(local_dir: Path) -> dict:
-    episodes_stats = load_jsonlines(local_dir / EPISODES_STATS_PATH)
+    episodes_stats_path = local_dir / EPISODES_STATS_PATH
+    if not episodes_stats_path.exists():
+        parquet_files = sorted(local_dir.glob(EPISODES_STATS_PARQUET_GLOB))
+        if not parquet_files:
+            stats = load_stats(local_dir)
+            episodes = load_episodes(local_dir)
+            return backward_compatible_episodes_stats(stats, episodes)
+        episodes_stats = []
+        for parquet_file in parquet_files:
+            episodes_stats.extend(pq.read_table(str(parquet_file)).to_pylist())
+    else:
+        episodes_stats = load_jsonlines(episodes_stats_path)
     return {
         item["episode_index"]: cast_stats_to_numpy(item["stats"])
         for item in sorted(episodes_stats, key=lambda x: x["episode_index"])

--- a/policy/AHA_WAM/AHAWAM/src/ahawam/datasets/lerobot/lerobot/lerobot_dataset.py
+++ b/policy/AHA_WAM/AHAWAM/src/ahawam/datasets/lerobot/lerobot/lerobot_dataset.py
@@ -14,7 +14,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import contextlib
+import hashlib
 import logging
+import re
 import shutil
 from pathlib import Path
 from typing import Callable, List, Literal
@@ -28,6 +30,7 @@ import torch
 import torch.utils
 import pyarrow.parquet as pq
 from datasets import concatenate_datasets, load_dataset
+from datasets.features import features as hf_features
 from huggingface_hub import HfApi, snapshot_download
 from huggingface_hub.constants import REPOCARD_NAME
 from huggingface_hub.errors import RevisionNotFoundError
@@ -78,6 +81,24 @@ from .datasets.video_utils import (
 import traceback
 
 CODEBASE_VERSION = "v2.1"
+
+if "List" not in hf_features._FEATURE_TYPES:
+    hf_features._FEATURE_TYPES["List"] = datasets.Sequence
+
+
+def get_lerobot_repo_id_for_root(repo_id: str, root: str | Path | None = None) -> str:
+    """Create a stable Hub-valid id for a local absolute LeRobot dataset root."""
+    if root is None:
+        return str(repo_id)
+    root_path = Path(root)
+    repo_id_str = str(repo_id)
+    if not root_path.is_absolute() and not repo_id_str.startswith("/"):
+        return repo_id_str
+
+    name = root_path.name or "dataset"
+    name = re.sub(r"[^A-Za-z0-9._-]+", "-", name).strip(".-") or "dataset"
+    digest = hashlib.sha1(str(root_path).encode("utf-8")).hexdigest()[:10]
+    return f"local_lerobot/{name}-{digest}"
 
 
 class LeRobotDatasetMetadata:
@@ -139,13 +160,30 @@ class LeRobotDatasetMetadata:
         return packaging.version.parse(self.info["codebase_version"])
 
     def get_data_file_path(self, ep_index: int) -> Path:
-        ep_chunk = self.get_episode_chunk(ep_index)
-        fpath = self.data_path.format(episode_chunk=ep_chunk, episode_index=ep_index)
+        episode = self.episodes.get(ep_index, {})
+        ep_chunk = episode.get("data/chunk_index", self.get_episode_chunk(ep_index))
+        file_index = episode.get("data/file_index", ep_chunk)
+        fpath = self.data_path.format(
+            episode_chunk=ep_chunk,
+            episode_index=ep_index,
+            chunk_index=ep_chunk,
+            file_index=file_index,
+        )
         return Path(fpath)
 
     def get_video_file_path(self, ep_index: int, vid_key: str) -> Path:
-        ep_chunk = self.get_episode_chunk(ep_index)
-        fpath = self.video_path.format(episode_chunk=ep_chunk, video_key=vid_key, episode_index=ep_index)
+        episode = self.episodes.get(ep_index, {})
+        chunk_key = f"videos/{vid_key}/chunk_index"
+        file_key = f"videos/{vid_key}/file_index"
+        ep_chunk = episode.get(chunk_key, self.get_episode_chunk(ep_index))
+        file_index = episode.get(file_key, ep_chunk)
+        fpath = self.video_path.format(
+            episode_chunk=ep_chunk,
+            video_key=vid_key,
+            episode_index=ep_index,
+            chunk_index=ep_chunk,
+            file_index=file_index,
+        )
         return Path(fpath)
 
     def get_episode_chunk(self, ep_index: int) -> int:
@@ -458,11 +496,11 @@ class LeRobotDataset(torch.utils.data.Dataset):
                 You can also use the 'pyav' decoder used by Torchvision, which used to be the default option, or 'video_reader' which is another decoder of Torchvision.
         """
         super().__init__()
-        self.repo_id = repo_id
         self.root = Path(root) if root else HF_LEROBOT_HOME / repo_id
+        self.repo_id = get_lerobot_repo_id_for_root(repo_id, self.root if root else None)
         self.image_transforms = image_transforms
         self.delta_timestamps = delta_timestamps
-        self.episodes = episodes
+        self.episodes = sorted(episodes) if episodes is not None else None
         self.tolerance_s = tolerance_s
         self.revision = revision if revision else CODEBASE_VERSION
         self.video_backend = video_backend if video_backend else get_safe_default_codec()
@@ -606,7 +644,7 @@ class LeRobotDataset(torch.utils.data.Dataset):
             ]
             fpaths += video_files
 
-        return fpaths
+        return list(dict.fromkeys(fpaths))
 
     def load_hf_dataset(self) -> datasets.Dataset:
         """hf_dataset contains all the observations, states, actions, rewards, etc."""
@@ -614,8 +652,19 @@ class LeRobotDataset(torch.utils.data.Dataset):
             path = str(self.root / "data")
             hf_dataset = load_dataset("parquet", data_dir=path, split="train")
         else:
-            files = [str(self.root / self.meta.get_data_file_path(ep_idx)) for ep_idx in self.episodes]
+            files = list(
+                dict.fromkeys(
+                    str(self.root / self.meta.get_data_file_path(ep_idx))
+                    for ep_idx in self.episodes
+                )
+            )
             hf_dataset = load_dataset("parquet", data_files=files, split="train")
+            selected_episodes = set(int(ep_idx) for ep_idx in self.episodes)
+            hf_dataset = hf_dataset.filter(
+                lambda ep_idx: int(ep_idx) in selected_episodes,
+                input_columns=["episode_index"],
+                desc="Filtering selected episodes",
+            )
 
         # TODO(aliberts): hf_dataset.set_format("torch")
         hf_dataset.set_transform(hf_transform_to_torch)
@@ -1095,7 +1144,10 @@ class MultiLeRobotDataset(torch.utils.data.Dataset):
         super().__init__()
         self.dataset_dirs = dataset_dirs
         ds_roots = [Path(ds_dir) for ds_dir in dataset_dirs]
-        ds_names = [ds_dir for ds_dir in dataset_dirs]
+        ds_names = [
+            get_lerobot_repo_id_for_root(ds_dir, ds_root)
+            for ds_dir, ds_root in zip(dataset_dirs, ds_roots, strict=True)
+        ]
         self.ds_names = ds_names
         self.ds_roots = ds_roots
         self.tolerances_s = tolerances_s if tolerances_s else dict.fromkeys(ds_names, 0.0001)

--- a/policy/AHA_WAM/AHAWAM/src/ahawam/datasets/lerobot/processors/ahawam_processor.py
+++ b/policy/AHA_WAM/AHAWAM/src/ahawam/datasets/lerobot/processors/ahawam_processor.py
@@ -108,6 +108,26 @@ class AHAWAMProcessor(BaseProcessor):
         return self
 
     def set_normalizer_from_stats(self, dataset_stats: Dict[str, Any] = None):
+        if dataset_stats is None:
+            raise ValueError(
+                "dataset_stats is None. Please set `pretrained_norm_stats` to a valid "
+                "stats JSON, or enable stats computation for this dataset."
+            )
+        for field in ("action", "state"):
+            if field not in dataset_stats or dataset_stats[field] is None:
+                raise ValueError(f"dataset_stats is missing `{field}` stats.")
+            missing_keys = [
+                meta["key"]
+                for meta in self.shape_meta.get(field, [])
+                if meta["key"] not in dataset_stats[field]
+                or dataset_stats[field][meta["key"]] is None
+            ]
+            if missing_keys:
+                available_keys = list(dataset_stats[field].keys())
+                raise ValueError(
+                    f"dataset_stats missing {field} keys {missing_keys}; "
+                    f"available keys are {available_keys}."
+                )
         self._normalizer = LinearNormalizer(
             use_stepwise_action_norm=self.use_stepwise_action_norm,
             shape_meta=self.shape_meta,

--- a/policy/AHA_WAM/AHAWAM/src/ahawam/datasets/lerobot/robot_video_dataset.py
+++ b/policy/AHA_WAM/AHAWAM/src/ahawam/datasets/lerobot/robot_video_dataset.py
@@ -29,6 +29,32 @@ def _is_main_process_without_init() -> bool:
 
 
 class RobotVideoDataset(torch.utils.data.Dataset):
+    lerobot_dataset_cls = BaseLerobotDataset
+
+    def _build_lerobot_dataset(
+        self,
+        *,
+        dataset_dirs,
+        shape_meta,
+        num_frames: int,
+        val_set_proportion: float,
+        is_training_set: bool,
+        global_sample_stride: int,
+        image_sample_indices,
+        skip_missing_episode_files: bool = False,
+    ):
+        return self.lerobot_dataset_cls(
+            dataset_dirs=dataset_dirs,
+            shape_meta=shape_meta,
+            obs_size=num_frames,
+            action_size=num_frames - 1,
+            val_set_proportion=val_set_proportion,
+            is_training_set=is_training_set,
+            global_sample_stride=global_sample_stride,
+            image_sample_indices=image_sample_indices,
+            skip_missing_episode_files=skip_missing_episode_files,
+        )
+
     def __init__(
         self,
         dataset_dirs,
@@ -46,6 +72,7 @@ class RobotVideoDataset(torch.utils.data.Dataset):
         global_sample_stride=1,
         action_video_freq_ratio: int = 1,
         skip_padding_as_possible: bool = False,
+        skip_missing_episode_files: bool = False,
         max_padding_retry: int = 3,
         concat_multi_camera: str = "horizontal",  # "horizontal", "vertical", "robotwin", or None
         override_instruction: Optional[
@@ -53,7 +80,6 @@ class RobotVideoDataset(torch.utils.data.Dataset):
         ] = None,  # whether to hardcode a specific instruction for all samples, for debugging
         num_history_frames: int = 0,
         history_frame_cache_size: int = 64,
-        prepend_episode_first_frame: bool = False,
         max_action_offset: int = 0,
         action_chunk_size: int = 16,
         action_horizon: int = 0,
@@ -112,15 +138,15 @@ class RobotVideoDataset(torch.utils.data.Dataset):
         self._image_offset_to_sample_position = {
             int(offset): i for i, offset in enumerate(image_sample_indices)
         }
-        self.lerobot_dataset = BaseLerobotDataset(
+        self.lerobot_dataset = self._build_lerobot_dataset(
             dataset_dirs=dataset_dirs,
             shape_meta=OmegaConf.to_container(shape_meta, resolve=True),
-            obs_size=num_frames,
-            action_size=num_frames - 1,
+            num_frames=num_frames,
             val_set_proportion=val_set_proportion,
             is_training_set=is_training_set,
             global_sample_stride=global_sample_stride,
             image_sample_indices=image_sample_indices,
+            skip_missing_episode_files=skip_missing_episode_files,
         )
 
         self.num_frames = num_frames
@@ -149,7 +175,6 @@ class RobotVideoDataset(torch.utils.data.Dataset):
         self.concat_multi_camera = concat_multi_camera
         self.override_instruction = override_instruction
         self.num_history_frames = int(num_history_frames)
-        self.prepend_episode_first_frame = bool(prepend_episode_first_frame)
         self._video_history_valid_len_cache: torch.Tensor | None = None
         self._video_history_valid_len_cache_key: tuple[int, int, int] | None = None
         self._history_frame_cache: OrderedDict[int, torch.Tensor] = OrderedDict()
@@ -186,6 +211,7 @@ class RobotVideoDataset(torch.utils.data.Dataset):
                         raise ValueError(
                             "Failed to resolve work directory for dataset stats."
                         )
+                    os.makedirs(work_dir, exist_ok=True)
                     save_dataset_stats_to_json(
                         dataset_stats, os.path.join(work_dir, "dataset_stats.json")
                     )
@@ -207,6 +233,7 @@ class RobotVideoDataset(torch.utils.data.Dataset):
                         raise ValueError(
                             "Failed to resolve work directory for dataset stats."
                         )
+                    os.makedirs(work_dir, exist_ok=True)
                     save_dataset_stats_to_json(
                         dataset_stats, os.path.join(work_dir, "dataset_stats.json")
                     )
@@ -217,16 +244,12 @@ class RobotVideoDataset(torch.utils.data.Dataset):
     def __len__(self):
         return len(self.lerobot_dataset)
 
-    def configure_video_history_memory(
-        self, *, num_history_frames: int, prepend_episode_first_frame: bool | None = None
-    ) -> None:
+    def configure_video_history_memory(self, *, num_history_frames: int) -> None:
         if int(num_history_frames) < 0:
             raise ValueError(
                 f"`num_history_frames` must be >= 0, got {num_history_frames}"
             )
         self.num_history_frames = int(num_history_frames)
-        if prepend_episode_first_frame is not None:
-            self.prepend_episode_first_frame = bool(prepend_episode_first_frame)
         self._video_history_valid_len_cache = None
         self._video_history_valid_len_cache_key = None
 
@@ -240,6 +263,19 @@ class RobotVideoDataset(torch.utils.data.Dataset):
         ep_idx = int(matches[0].item())
         return int(starts[ep_idx].item()), int(ends[ep_idx].item())
 
+    def _describe_sample_index(self, sample_idx: int) -> str:
+        dataset_dirs = getattr(self.lerobot_dataset, "dataset_dirs", None)
+        starts = self.lerobot_dataset.episode_data_index["from"]
+        ends = self.lerobot_dataset.episode_data_index["to"]
+        if len(starts) > 0 and len(ends) > 0:
+            bounds = f"episode_bounds=[{int(starts[0])}, {int(ends[-1])})"
+        else:
+            bounds = "episode_bounds=<empty>"
+        return (
+            f"idx={int(sample_idx)} len={len(self)} {bounds} "
+            f"dataset_dirs={dataset_dirs}"
+        )
+
     def get_video_history_valid_len_for_index(self, sample_idx: int) -> int:
         if self.num_history_frames <= 0:
             return 0
@@ -248,15 +284,7 @@ class RobotVideoDataset(torch.utils.data.Dataset):
         if horizon_stride <= 0:
             raise ValueError(f"Invalid horizon stride: {horizon_stride}")
         available_horizons = max(0, (int(sample_idx) - ep_start) // horizon_stride)
-        valid_len = min(int(self.num_history_frames), int(available_horizons))
-        if self.prepend_episode_first_frame and int(sample_idx) > ep_start:
-            first_frame_already_included = (
-                valid_len > 0
-                and (int(sample_idx) - horizon_stride * valid_len) == ep_start
-            )
-            if not first_frame_already_included and valid_len < self.num_history_frames:
-                valid_len += 1
-        return valid_len
+        return min(int(self.num_history_frames), int(available_horizons))
 
     def get_video_history_valid_len_for_all_indices(self) -> torch.Tensor:
         dataset_len = len(self.lerobot_dataset)
@@ -287,15 +315,6 @@ class RobotVideoDataset(torch.utils.data.Dataset):
                 ep_valid_len = torch.div(
                     rel, horizon_stride, rounding_mode="floor"
                 ).clamp(max=int(self.num_history_frames))
-                if self.prepend_episode_first_frame:
-                    bonus = (
-                        (rel > 0)
-                        & (ep_valid_len < self.num_history_frames)
-                        & (rel % horizon_stride != 0)
-                    ).to(dtype=torch.long)
-                    ep_valid_len = (ep_valid_len + bonus).clamp(
-                        max=int(self.num_history_frames)
-                    )
                 valid_len[start:end] = ep_valid_len.to(dtype=torch.int16)
 
         self._video_history_valid_len_cache = valid_len
@@ -521,14 +540,6 @@ class RobotVideoDataset(torch.utils.data.Dataset):
                 history_indices.append(history_idx)
         valid_len = len(history_indices)
 
-        if self.prepend_episode_first_frame and sample_idx > ep_start:
-            if ep_start not in history_indices:
-                if valid_len < self.num_history_frames:
-                    history_indices.insert(0, ep_start)
-                    valid_len += 1
-                else:
-                    history_indices[0] = ep_start
-
         frames = [self._get_processed_single_frame(idx) for idx in history_indices]
         if frames:
             pad_frame = frames[0].new_zeros(frames[0].shape)
@@ -708,7 +719,8 @@ class RobotVideoDataset(torch.utils.data.Dataset):
             data = self._get(idx)
         except Exception as e:
             print(
-                f"Error processing sample idx {idx}: {e}. Returning a random sample instead."
+                f"Error processing sample {self._describe_sample_index(idx)}: {e}. "
+                "Returning a random sample instead."
             )
             # trace back
             print(traceback.format_exc())

--- a/policy/AHA_WAM/AHAWAM/src/ahawam/models/wan22/ahawam.py
+++ b/policy/AHA_WAM/AHAWAM/src/ahawam/models/wan22/ahawam.py
@@ -18,8 +18,6 @@ class AHAWAM(AHAWAMChunkBase):
         num_history_frames: int = 0,
         action_video_read_mode: str = "current_only",
         video_rope_frame_stride: int = 1,
-        detach_history_kv_during_training: bool = True,
-        prepend_episode_first_frame: bool = False,
     ) -> None:
         self.num_history_frames = int(num_history_frames)
         if self.num_history_frames < 0:
@@ -35,11 +33,6 @@ class AHAWAM(AHAWAMChunkBase):
                 "`video_rope_frame_stride` must be positive, "
                 f"got {video_rope_frame_stride}."
             )
-        self.detach_history_kv_during_training = bool(
-            detach_history_kv_during_training
-        )
-        self.prepend_episode_first_frame = bool(prepend_episode_first_frame)
-
     def _configured_num_history_frames(self) -> int:
         return int(getattr(self, "num_history_frames", 0))
 
@@ -62,12 +55,6 @@ class AHAWAM(AHAWAMChunkBase):
         if stride <= 0:
             raise ValueError(f"`video_rope_frame_stride` must be positive, got {stride}.")
         return stride
-
-    def _configured_detach_history_kv_during_training(self) -> bool:
-        return bool(getattr(self, "detach_history_kv_during_training", True))
-
-    def _configured_prepend_episode_first_frame(self) -> bool:
-        return bool(getattr(self, "prepend_episode_first_frame", False))
 
     def _get_video_history_valid_len(
         self,
@@ -505,14 +492,7 @@ class AHAWAM(AHAWAMChunkBase):
 
         if num_history > 0:
             prior_entries.append(video_kv_cache)
-            if self._configured_prepend_episode_first_frame() and len(prior_entries) > 1:
-                pinned = prior_entries[0]
-                max_sliding = num_history - 1
-                sliding = prior_entries[1:]
-                if len(sliding) > max_sliding:
-                    sliding = sliding[-max_sliding:]
-                prior_entries = [pinned] + sliding
-            elif len(prior_entries) > num_history:
+            if len(prior_entries) > num_history:
                 prior_entries = prior_entries[-num_history:]
             self._history_kv_entries = prior_entries
 

--- a/policy/AHA_WAM/AHAWAM/src/ahawam/runtime.py
+++ b/policy/AHA_WAM/AHAWAM/src/ahawam/runtime.py
@@ -84,8 +84,6 @@ def create_ahawam(
     max_action_offset: int = 0,
     action_video_read_mode: str = "current_only",
     video_rope_frame_stride: int = 1,
-    detach_history_kv_during_training: bool = True,
-    prepend_episode_first_frame: bool = False,
     action_train_timestep_mode: str = "per_chunk",
     tokenizer_max_len: int = 512,
     load_text_encoder: bool = True,
@@ -99,7 +97,6 @@ def create_ahawam(
     mot_checkpoint_mixed_attn: bool = True,
     redirect_common_files: bool = True,
     checkpoint_shape_adapt: bool = False,
-    prior_only_training: bool = False,
     model_dtype: torch.dtype = torch.bfloat16,
     device: str = "cuda",
 ):
@@ -197,8 +194,6 @@ def create_ahawam(
         num_history_frames=int(num_history_frames),
         action_video_read_mode=str(action_video_read_mode),
         video_rope_frame_stride=int(video_rope_frame_stride),
-        detach_history_kv_during_training=bool(detach_history_kv_during_training),
-        prepend_episode_first_frame=bool(prepend_episode_first_frame),
     )
     max_action_offset = int(max_action_offset)
     if max_action_offset < 0:
@@ -216,9 +211,6 @@ def _configure_dataset_history(dataset, model_cfg: DictConfig | None) -> None:
         return
     dataset.configure_video_history_memory(
         num_history_frames=int(model_cfg.get("num_history_frames", 0)),
-        prepend_episode_first_frame=bool(
-            model_cfg.get("prepend_episode_first_frame", False)
-        ),
     )
 
 

--- a/policy/AHA_WAM/AHAWAM/src/ahawam/trainer.py
+++ b/policy/AHA_WAM/AHAWAM/src/ahawam/trainer.py
@@ -49,12 +49,14 @@ class Wan22Trainer:
         self.eval_num_inference_steps = int(cfg.eval_num_inference_steps)
         self.gradient_accumulation_steps = int(cfg.gradient_accumulation_steps)
         self.max_grad_norm = float(cfg.max_grad_norm)
+        self.manual_gc_every = int(cfg.get("manual_gc_every", 1))
         self.seed = int(cfg.seed)
         self.history_aware_batching = bool(cfg.get("history_aware_batching", False))
         self.freeze_video_dit = bool(cfg.get("freeze_video_dit", False))
 
         self.resume = cfg.resume
         self.resume_global_batch_size = cfg.get("resume_global_batch_size", None)
+        self.resume_dataloader_state = bool(cfg.get("resume_dataloader_state", True))
         self.init_checkpoint = cfg.get("init_checkpoint", None)
         self.mixed_precision = str(cfg.mixed_precision).strip().lower()
         if self.mixed_precision not in {"no", "fp16", "bf16"}:
@@ -89,7 +91,7 @@ class Wan22Trainer:
             zero_stage = "n/a"
 
         logger.info(
-            "Accelerate training: distributed_type=%s zero_stage=%s world_size=%d process_index=%d cfg_mixed_precision=%s accelerator_mixed_precision=%s grad_accum=%d grad_clip=%.4f",
+            "Accelerate training: distributed_type=%s zero_stage=%s world_size=%d process_index=%d cfg_mixed_precision=%s accelerator_mixed_precision=%s grad_accum=%d grad_clip=%.4f manual_gc_every=%d",
             self.accelerator.distributed_type,
             zero_stage,
             self.accelerator.num_processes,
@@ -98,6 +100,7 @@ class Wan22Trainer:
             self.accelerator.mixed_precision,
             self.gradient_accumulation_steps,
             self.max_grad_norm,
+            self.manual_gc_every,
         )
         logger.info("using accelerator.device=%s", self.accelerator.device)
         worker_init_fn = set_global_seed(self.seed, get_worker_init_fn=True)
@@ -123,6 +126,7 @@ class Wan22Trainer:
         self._load_weights_before_prepare()
 
         trainable_params = [p for p in self.model.dit.parameters() if p.requires_grad]
+        dit_trainable_param_count = sum(p.numel() for p in trainable_params)
         extra_trainable_modules: list[nn.Module] = []
         get_extra_modules = getattr(
             self.model, "get_additional_trainable_modules", None
@@ -141,11 +145,18 @@ class Wan22Trainer:
                 extra_trainable_modules.append(proprio_encoder)
         for module in extra_trainable_modules:
             trainable_params.extend(p for p in module.parameters() if p.requires_grad)
+        trainable_param_count = sum(p.numel() for p in trainable_params)
         if not trainable_params:
             raise ValueError(
                 "No trainable parameters remain after applying freeze settings. "
                 "Disable `freeze_video_dit` or enable another trainable module."
             )
+        logger.info(
+            "Trainable parameters: total=%.3fB dit=%.3fB extra=%.3fM",
+            trainable_param_count / 1e9,
+            dit_trainable_param_count / 1e9,
+            (trainable_param_count - dit_trainable_param_count) / 1e6,
+        )
         self.optimizer = torch.optim.AdamW(
             trainable_params,
             lr=self.learning_rate,
@@ -216,6 +227,7 @@ class Wan22Trainer:
             "forward_time": 0.0,
             "backward_time": 0.0,
             "optimizer_time": 0.0,
+            "gc_time": 0.0,
         }
 
     def _update_profile_window(
@@ -225,12 +237,14 @@ class Wan22Trainer:
         forward_time: float,
         backward_time: float,
         optimizer_time: float,
+        gc_time: float,
     ):
         self._profile_window["steps"] += 1
         self._profile_window["data_time"] += float(data_time)
         self._profile_window["forward_time"] += float(forward_time)
         self._profile_window["backward_time"] += float(backward_time)
         self._profile_window["optimizer_time"] += float(optimizer_time)
+        self._profile_window["gc_time"] += float(gc_time)
 
     def _consume_profile_window(self):
         steps = max(int(self._profile_window["steps"]), 1)
@@ -239,6 +253,7 @@ class Wan22Trainer:
             "forward_time": self._profile_window["forward_time"] / steps,
             "backward_time": self._profile_window["backward_time"] / steps,
             "optimizer_time": self._profile_window["optimizer_time"] / steps,
+            "gc_time": self._profile_window["gc_time"] / steps,
         }
         self._profile_window = self._reset_profile_window()
         return profile
@@ -282,16 +297,30 @@ class Wan22Trainer:
         self.wandb_run = None
 
     def _build_loader(self, dataset, worker_init_fn=None):
-        sampler_cls = ResumableEpochSampler
-        if self.history_aware_batching:
-            sampler_cls = HistoryAwareResumableEpochSampler
-            logger.info("Using history-aware train sampler.")
-        self.train_sampler = sampler_cls(
-            dataset=dataset,
-            seed=self.seed,
-            batch_size=self.batch_size,
-            num_processes=self.accelerator.num_processes,
-        )
+        build_train_sampler = getattr(dataset, "build_train_sampler", None)
+        if callable(build_train_sampler):
+            self.train_sampler = build_train_sampler(
+                seed=self.seed,
+                batch_size=self.batch_size,
+                num_processes=self.accelerator.num_processes,
+                gradient_accumulation_steps=self.gradient_accumulation_steps,
+                max_steps=self.max_steps,
+            )
+            logger.info(
+                "Using dataset-provided train sampler: %s",
+                type(self.train_sampler).__name__,
+            )
+        else:
+            sampler_cls = ResumableEpochSampler
+            if self.history_aware_batching:
+                sampler_cls = HistoryAwareResumableEpochSampler
+                logger.info("Using history-aware train sampler.")
+            self.train_sampler = sampler_cls(
+                dataset=dataset,
+                seed=self.seed,
+                batch_size=self.batch_size,
+                num_processes=self.accelerator.num_processes,
+            )
         loader_kwargs = {
             "dataset": dataset,
             "batch_size": self.batch_size,
@@ -401,6 +430,13 @@ class Wan22Trainer:
         eta_h, eta_rem = divmod(eta_seconds, 3600)
         eta_m, eta_s = divmod(eta_rem, 60)
         return f"{eta_h:02d}:{eta_m:02d}:{eta_s:02d}", steps_per_sec
+
+    def _samples_per_optimizer_step(self) -> int:
+        return (
+            self.batch_size
+            * max(int(self.accelerator.num_processes), 1)
+            * max(int(self.gradient_accumulation_steps), 1)
+        )
 
     def _load_weights_before_prepare(self):
         """Load model weights BEFORE accelerator.prepare() to ensure DeepSpeed
@@ -1002,7 +1038,11 @@ class Wan22Trainer:
                 payload = json.load(f)
             self.global_step = int(payload["global_step"])
 
-            if "epoch" in payload and "batch_in_epoch" in payload:
+            if (
+                self.resume_dataloader_state
+                and "epoch" in payload
+                and "batch_in_epoch" in payload
+            ):
                 self.epoch = int(payload["epoch"])
                 self.batch_in_epoch = int(payload["batch_in_epoch"])
                 self.train_sampler.set_epoch_offset(self.epoch)
@@ -1019,10 +1059,17 @@ class Wan22Trainer:
                 self.epoch = 0
                 self.batch_in_epoch = 0
                 self.train_sampler.clear_resume_batch_offset()
-                logger.warning(
-                    "State file does not contain `epoch`/`batch_in_epoch`; "
-                    "optimizer/scheduler were restored, but dataloader progress resume is skipped."
-                )
+                if self.resume_dataloader_state:
+                    logger.warning(
+                        "State file does not contain `epoch`/`batch_in_epoch`; "
+                        "optimizer/scheduler were restored, but dataloader progress resume is skipped."
+                    )
+                else:
+                    logger.warning(
+                        "Skipping dataloader progress restore because "
+                        "`resume_dataloader_state=false`; optimizer/scheduler/random "
+                        "states were restored, sampler progress restarts from epoch 0."
+                    )
             self.accelerator.wait_for_everyone()
             return
 
@@ -1091,6 +1138,7 @@ class Wan22Trainer:
                     else self.accelerator.unwrap_model(self.model)
                 )
                 data_time = data_ready_time - last_step_end_time
+                gc_time = 0.0
                 forward_start_time = time.perf_counter()
 
                 with self.accelerator.autocast():
@@ -1110,9 +1158,13 @@ class Wan22Trainer:
                     self.optimizer.zero_grad(set_to_none=True)
                     self.global_step += 1
 
-                    # Manual GC every step: promptly releases Python references to
-                    # CUDA tensors, preventing allocator fragmentation/defrag stalls.
-                    gc.collect()
+                    if (
+                        self.manual_gc_every > 0
+                        and self.global_step % self.manual_gc_every == 0
+                    ):
+                        gc_start_time = time.perf_counter()
+                        gc.collect()
+                        gc_time = time.perf_counter() - gc_start_time
                     current_lr = float(self.optimizer.param_groups[0]["lr"])
                     optimizer_time = optimizer_end_time - backward_end_time
                     should_log = (
@@ -1127,6 +1179,7 @@ class Wan22Trainer:
                     forward_time=forward_end_time - forward_start_time,
                     backward_time=backward_end_time - forward_end_time,
                     optimizer_time=optimizer_time,
+                    gc_time=gc_time,
                 )
                 last_step_end_time = time.perf_counter()
 
@@ -1174,19 +1227,18 @@ class Wan22Trainer:
                                 % (
                                     current_lr,
                                     steps_per_sec,
-                                    steps_per_sec
-                                    * self.batch_size
-                                    * self.accelerator.num_processes,
+                                    steps_per_sec * self._samples_per_optimizer_step(),
                                     eta_str,
                                 )
                             )
                             description += (
-                                " timing(data=%.3fs fwd=%.3fs bwd=%.3fs opt=%.3fs)"
+                                " timing(data=%.3fs fwd=%.3fs bwd=%.3fs opt=%.3fs gc=%.3fs)"
                                 % (
                                     profile_metrics["data_time"],
                                     profile_metrics["forward_time"],
                                     profile_metrics["backward_time"],
                                     profile_metrics["optimizer_time"],
+                                    profile_metrics["gc_time"],
                                 )
                             )
                             lambda_state = getattr(self, "_lambda_state", None)
@@ -1202,8 +1254,7 @@ class Wan22Trainer:
                                 "train/lr": current_lr,
                                 "performance/steps_per_sec": steps_per_sec,
                                 "performance/samples_per_sec": steps_per_sec
-                                * self.batch_size
-                                * self.accelerator.num_processes,
+                                * self._samples_per_optimizer_step(),
                                 "performance/data_time_s": profile_metrics["data_time"],
                                 "performance/forward_time_s": profile_metrics[
                                     "forward_time"
@@ -1214,6 +1265,7 @@ class Wan22Trainer:
                                 "performance/optimizer_time_s": profile_metrics[
                                     "optimizer_time"
                                 ],
+                                "performance/gc_time_s": profile_metrics["gc_time"],
                             }
                             for key, value in global_loss_metrics.items():
                                 wandb_payload[f"train/{key}"] = value

--- a/policy/AHA_WAM/README.md
+++ b/policy/AHA_WAM/README.md
@@ -44,6 +44,7 @@ If preprocessing fails on unresolved Hydra placeholders in `configs/model/ahawam
 cd XPolicyLab/policy/AHA_WAM
 export AHA_WAM_TRAIN_DATASET_DIR=/path/to/RoboDojo_lerobot_v21_video
 export DIFFSYNTH_MODEL_BASE_PATH=/path/to/diffsynth/model/cache
+export AHA_WAM_RESUME=/path/to/official-compatible/states_5000
 
 bash train.sh <bench_name> <ckpt_name> <env_cfg_type> <action_type> <seed> <gpu_id>
 
@@ -52,6 +53,12 @@ bash train.sh RoboDojo cotrain arx_x5 joint 0 0
 ```
 
 Checkpoints land in `checkpoints/<bench_name>-<ckpt_name>-<env_cfg_type>-<action_type>-<seed>/`; at eval time `ckpt_name` may be the short run name, the full run-directory name, or a path. The training dataset must contain `meta/`, `dataset_stats.json`, and a T5 text-embedding cache at `text_embeds_cache/` unless overridden via `AHA_WAM_TRAIN_DATASET_STATS_PATH` / `AHA_WAM_TEXT_EMBED_CACHE_DIR`. Multi-process count is inferred from a comma-separated `gpu_id`.
+
+The default task is `robodojo_ahawam_finetune_32_kv_xpolicy`: batch size 8,
+gradient accumulation 2, learning rate `1e-5`, 32 epochs / 30,000 max steps,
+and GC every 50 optimizer steps. Set `AHA_WAM_RESUME` to the reference
+`states_5000`-compatible state for a true official-style finetune; an unset
+resume starts from the configured base weights and is not equivalent.
 
 ## Evaluation
 
@@ -64,7 +71,7 @@ bash eval.sh <bench_name> <task_name> <ckpt_name> <env_cfg_type> <action_type> <
 bash eval.sh RoboDojo stack_bowls RoboDojo-cotrain-arx_x5-joint-0 arx_x5 joint 0 0 0 <policy_conda_env> <eval_env_conda_env>
 ```
 
-`EVAL_ENV_TYPE=debug` runs the offline wiring check (no simulator); leave it unset or set `EVAL_ENV_TYPE=sim` for RoboDojo simulation. For split-machine deployment via `setup_eval_policy_server.sh` / `setup_eval_env_client.sh`, follow the [Deployment Flow](../../README.md#-deployment-flow).
+`EVAL_ENV_TYPE=debug` runs the offline wiring check (no simulator); leave it unset or set `EVAL_ENV_TYPE=sim` for RoboDojo simulation. AHA-WAM batch evaluation is intentionally disabled because one model instance owns one mutable history state; use one policy-server process per environment. For split-machine deployment via `setup_eval_policy_server.sh` / `setup_eval_env_client.sh`, follow the [Deployment Flow](../../README.md#-deployment-flow).
 
 ## Configuration
 
@@ -86,7 +93,7 @@ Environment variables used by the adapter scripts:
 | `AHA_WAM_ENV_CFG_ROOT` | Optional env config root; defaults to `<repo>/env_cfg`. |
 | `AHA_WAM_APPTAINER_IMAGE` | Optional Apptainer image for the policy server. |
 | `AHA_WAM_APPTAINER_BINDS` | Optional Apptainer bind arguments when using `AHA_WAM_APPTAINER_IMAGE`. |
-| `AHA_WAM_CHUNKS_PER_VIDEO_PREFILL` | Optional video prefill cadence; default is `4`. |
+| `AHA_WAM_CHUNKS_PER_VIDEO_PREFILL` | Optional video prefill cadence; official RobotWin-style default is `2`. |
 | `AHA_WAM_ALLOW_DUMMY_POLICY` | Debug-only option to skip real checkpoint/stats loading. |
 | `AHA_WAM_DEBUG_EVAL_EPISODE_NUM` | Debug-client episode count override. |
 | `XPOLICYLAB_BENCH_ROOT` | Optional client `--root_dir` override; defaults to the RoboDojo repo root. |

--- a/policy/AHA_WAM/deploy.yml
+++ b/policy/AHA_WAM/deploy.yml
@@ -17,7 +17,7 @@ action_dim: null
 seed: null
 
 elava_root: null
-task_config: robodojo_local_history_updated_kv_prior_only_16
+task_config: robodojo_ahawam_finetune_32_kv_xpolicy
 checkpoint_path: null
 dataset_stats_path: null
 diffsynth_model_base_path: null
@@ -28,8 +28,7 @@ device: cuda
 mixed_precision: bf16
 action_horizon: 64
 replan_steps: 16
-chunks_per_video_prefill: 4
-prepend_episode_first_frame: true
+chunks_per_video_prefill: 2
 num_inference_steps: 10
 sigma_shift: null
 text_cfg_scale: 1.0

--- a/policy/AHA_WAM/model.py
+++ b/policy/AHA_WAM/model.py
@@ -203,8 +203,6 @@ class Model(ModelTemplate):
         self.pending_actions: deque[np.ndarray] = deque()
         self.last_obs = None
         self.last_instruction = self.default_instruction
-        self._batch_obs: dict[int, dict] = {}
-        self._batch_instruction: dict[int, str] = {}
         self.allow_dummy_policy = _parse_bool(self.model_cfg.get("allow_dummy_policy", False))
         self._chunks_since_video_prefill = 0
 
@@ -233,10 +231,12 @@ class Model(ModelTemplate):
             self.policy = None
             self.action_horizon = int(self.model_cfg.get("action_horizon") or 64)
             self.replan_steps = int(self.model_cfg.get("replan_steps") or 16)
+            self.action_chunk_size = int(self.model_cfg.get("action_chunk_size") or 16)
             self.chunks_per_video_prefill = int(
                 self.model_cfg.get("chunks_per_video_prefill") or max(1, self.action_horizon // self.replan_steps)
             )
-            self.video_prefill_action_horizon = self._resolve_video_prefill_action_horizon(self.replan_steps)
+            self._validate_rollout_config()
+            self.video_prefill_action_horizon = self._resolve_video_prefill_action_horizon(self.action_chunk_size)
             print("[aha-wam] allow_dummy_policy=true; real model loading is skipped.")
         else:
             from ahawam.datasets.lerobot.robot_video_dataset import DEFAULT_PROMPT
@@ -245,10 +245,11 @@ class Model(ModelTemplate):
             self.policy = self._load_policy()
             self.action_horizon = int(self.model_cfg.get("action_horizon") or self.policy.action_horizon)
             self.replan_steps = int(self.model_cfg.get("replan_steps") or self.policy.model.action_chunk_size)
-            self.replan_steps = min(self.replan_steps, int(self.policy.model.action_chunk_size))
+            self.action_chunk_size = int(self.policy.model.action_chunk_size)
+            self._validate_rollout_config()
             self.chunks_per_video_prefill = self._resolve_chunks_per_video_prefill()
             self.video_prefill_action_horizon = self._resolve_video_prefill_action_horizon(
-                int(self.policy.model.action_chunk_size)
+                self.action_chunk_size
             )
             self._warmup()
         print(
@@ -267,15 +268,25 @@ class Model(ModelTemplate):
         configs_root = self.elava_root / "configs"
         task_name = str(self.model_cfg.get("task_config") or self.model_cfg.get("sim_task"))
         overrides = [f"task={task_name}"]
-        if "prepend_episode_first_frame" in self.model_cfg:
-            overrides.append(
-                "model.prepend_episode_first_frame="
-                f"{str(_parse_bool(self.model_cfg.get('prepend_episode_first_frame'))).lower()}"
-            )
         if GlobalHydra.instance().is_initialized():
             GlobalHydra.instance().clear()
         with initialize_config_dir(version_base="1.3", config_dir=str(configs_root)):
             return compose(config_name="train.yaml", overrides=overrides)
+
+    def _validate_rollout_config(self) -> None:
+        if self.action_horizon <= 0:
+            raise ValueError(f"action_horizon must be positive, got {self.action_horizon}.")
+        if self.action_horizon % self.action_chunk_size != 0:
+            raise ValueError(
+                "action_horizon must be divisible by action_chunk_size: "
+                f"{self.action_horizon} % {self.action_chunk_size} != 0."
+            )
+        if self.replan_steps != self.action_chunk_size:
+            raise ValueError(
+                "AHA-WAM advances one complete internal action chunk per inference call; "
+                "replan_steps must therefore equal action_chunk_size: "
+                f"{self.replan_steps} != {self.action_chunk_size}."
+            )
 
     def _load_policy(self):
         from hydra.utils import instantiate
@@ -511,12 +522,11 @@ class Model(ModelTemplate):
         self.last_instruction = _get_instruction(obs, self.default_instruction)
 
     def update_obs_batch(self, obs_list):
-        self._batch_obs = {}
-        self._batch_instruction = {}
-        for obs in obs_list:
-            env_idx = int(obs["env_idx"])
-            self._batch_obs[env_idx] = obs
-            self._batch_instruction[env_idx] = _get_instruction(obs, self.default_instruction)
+        del obs_list
+        raise NotImplementedError(
+            "AHA-WAM keeps mutable rollout/history state and does not support batched "
+            "multi-environment evaluation. Run one policy-server process per environment."
+        )
 
     def get_action(self):
         if self.last_obs is None:
@@ -528,13 +538,11 @@ class Model(ModelTemplate):
         return _unpack_robot_state(actions, self.action_type, self.robot_action_dim_info)
 
     def get_action_batch(self, env_idx_list):
-        # The underlying AHAWAM history state is single-rollout stateful. Use one process per
-        # environment for true parallel eval; this fallback is for debug compatibility only.
-        results = []
-        for env_idx in env_idx_list:
-            self.update_obs(self._batch_obs[int(env_idx)])
-            results.append(self.get_action())
-        return results
+        del env_idx_list
+        raise NotImplementedError(
+            "AHA-WAM batched evaluation is disabled because sharing one model instance "
+            "would contaminate rollout/history state across environments."
+        )
 
     def reset(self):
         self.pending_actions.clear()

--- a/policy/AHA_WAM/setup_eval_env_client.sh
+++ b/policy/AHA_WAM/setup_eval_env_client.sh
@@ -53,6 +53,12 @@ print(str(data.get("eval_batch", False)).lower())
 PY
 )
 
+if [[ "${eval_batch}" == "true" ]]; then
+    echo "[ERROR] AHA-WAM eval_batch=true is unsupported: one model instance has a single mutable rollout/history state." >&2
+    echo "[ERROR] Use one policy-server process per environment instead." >&2
+    exit 1
+fi
+
 # shellcheck source=../../utils/resolve_eval_env_type.sh
 source "${UTILS_DIR}/resolve_eval_env_type.sh"
 eval_env_mode="$(resolve_eval_env_type)" || exit 1

--- a/policy/AHA_WAM/setup_eval_policy_server.sh
+++ b/policy/AHA_WAM/setup_eval_policy_server.sh
@@ -47,10 +47,9 @@ fi
 checkpoint_path="${AHA_WAM_CHECKPOINT_PATH:-}"
 dataset_stats_path="${AHA_WAM_DATASET_STATS_PATH:-}"
 diffsynth_model_base_path="${DIFFSYNTH_MODEL_BASE_PATH:-}"
-task_config="${AHA_WAM_TASK_CONFIG:-robodojo_local_history_updated_kv_prior_only_16}"
+task_config="${AHA_WAM_TASK_CONFIG:-robodojo_ahawam_finetune_32_kv_xpolicy}"
 allow_dummy_policy="${AHA_WAM_ALLOW_DUMMY_POLICY:-false}"
-chunks_per_video_prefill="${AHA_WAM_CHUNKS_PER_VIDEO_PREFILL:-4}"
-prepend_episode_first_frame="${AHA_WAM_PREPEND_EPISODE_FIRST_FRAME:-true}"
+chunks_per_video_prefill="${AHA_WAM_CHUNKS_PER_VIDEO_PREFILL:-2}"
 env_cfg_root="${AHA_WAM_ENV_CFG_ROOT:-${BENCH_ROOT}/env_cfg}"
 
 if [[ -z "${checkpoint_path}" && "${allow_dummy_policy}" != "true" ]]; then
@@ -155,8 +154,7 @@ python -u "${XPL_ROOT}/setup_policy_server.py" \
         dataset_stats_path="${DATASET_STATS_PATH}" \
         diffsynth_model_base_path="${AHA_WAM_DIFFSYNTH_MODEL_BASE_PATH}" \
         allow_dummy_policy="${ALLOW_DUMMY_POLICY}" \
-        chunks_per_video_prefill="${CHUNKS_PER_VIDEO_PREFILL}" \
-        prepend_episode_first_frame="${PREPEND_EPISODE_FIRST_FRAME}"
+        chunks_per_video_prefill="${CHUNKS_PER_VIDEO_PREFILL}"
 BASH
 
 export XPL_ROOT
@@ -181,7 +179,6 @@ export DATASET_STATS_PATH="${dataset_stats_path}"
 export AHA_WAM_DIFFSYNTH_MODEL_BASE_PATH="${diffsynth_model_base_path}"
 export ALLOW_DUMMY_POLICY="${allow_dummy_policy}"
 export CHUNKS_PER_VIDEO_PREFILL="${chunks_per_video_prefill}"
-export PREPEND_EPISODE_FIRST_FRAME="${prepend_episode_first_frame}"
 
 if command -v apptainer >/dev/null 2>&1 && [[ -n "${apptainer_image}" ]]; then
     apptainer exec --cleanenv \
@@ -210,7 +207,6 @@ if command -v apptainer >/dev/null 2>&1 && [[ -n "${apptainer_image}" ]]; then
             AHA_WAM_DIFFSYNTH_MODEL_BASE_PATH="${AHA_WAM_DIFFSYNTH_MODEL_BASE_PATH}" \
             ALLOW_DUMMY_POLICY="${ALLOW_DUMMY_POLICY}" \
             CHUNKS_PER_VIDEO_PREFILL="${CHUNKS_PER_VIDEO_PREFILL}" \
-            PREPEND_EPISODE_FIRST_FRAME="${PREPEND_EPISODE_FIRST_FRAME}" \
             bash -lc "${SERVER_BODY}"
 else
     echo -e "\033[33m[SERVER] apptainer not found; falling back to local conda environment.\033[0m"

--- a/policy/AHA_WAM/train.sh
+++ b/policy/AHA_WAM/train.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # XPolicyLab-compatible training wrapper for the aha-wam RoboDojo model.
 # It intentionally launches only the task/model used by this policy:
-#   task=robodojo_local_history_updated_kv_prior_only_16
+#   task=robodojo_ahawam_finetune_32_kv_xpolicy
 #   model=ahawam
 #
 # Usage:
@@ -41,7 +41,7 @@ fi
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 POLICY_DIR="${ROOT_DIR}/XPolicyLab/policy/AHA_WAM"
 AHA_WAM_PROJECT_ROOT="${AHA_WAM_PROJECT_ROOT:-${POLICY_DIR}/AHAWAM}"
-TASK_CONFIG="${AHA_WAM_TASK_CONFIG:-robodojo_local_history_updated_kv_prior_only_16}"
+TASK_CONFIG="${AHA_WAM_TASK_CONFIG:-robodojo_ahawam_finetune_32_kv_xpolicy}"
 DATASET_DIR="${AHA_WAM_TRAIN_DATASET_DIR:?set AHA_WAM_TRAIN_DATASET_DIR to your RoboDojo LeRobot dataset dir}"
 DATASET_STATS_PATH="${AHA_WAM_TRAIN_DATASET_STATS_PATH:-${DATASET_DIR}/dataset_stats.json}"
 TEXT_CACHE_DIR="${AHA_WAM_TEXT_EMBED_CACHE_DIR:-${DATASET_DIR}/text_embeds_cache}"
@@ -52,11 +52,13 @@ ckpt_setting="${bench_name}-${ckpt_name}-${env_cfg_type}-${action_type}-${seed}"
 RUN_ID="${RUN_ID:-${ckpt_setting}}"
 
 batch_size="${AHA_WAM_BATCH_SIZE:-8}"
-gradient_accumulation_steps="${AHA_WAM_GRADIENT_ACCUMULATION_STEPS:-8}"
-num_workers="${AHA_WAM_NUM_WORKERS:-8}"
-num_epochs="${AHA_WAM_NUM_EPOCHS:-20}"
-max_steps="${AHA_WAM_MAX_STEPS:-null}"
-learning_rate="${AHA_WAM_LEARNING_RATE:-6e-6}"
+gradient_accumulation_steps="${AHA_WAM_GRADIENT_ACCUMULATION_STEPS:-2}"
+num_workers="${AHA_WAM_NUM_WORKERS:-6}"
+num_epochs="${AHA_WAM_NUM_EPOCHS:-32}"
+max_steps="${AHA_WAM_MAX_STEPS:-30000}"
+learning_rate="${AHA_WAM_LEARNING_RATE:-1e-5}"
+manual_gc_every="${AHA_WAM_MANUAL_GC_EVERY:-50}"
+resume_dataloader_state="${AHA_WAM_RESUME_DATALOADER_STATE:-false}"
 save_every="${AHA_WAM_SAVE_EVERY:-2500}"
 eval_every="${AHA_WAM_EVAL_EVERY:-500}"
 log_every="${AHA_WAM_LOG_EVERY:-10}"
@@ -119,6 +121,8 @@ train_args=(
     "num_epochs=${num_epochs}"
     "max_steps=${max_steps}"
     "learning_rate=${learning_rate}"
+    "manual_gc_every=${manual_gc_every}"
+    "resume_dataloader_state=${resume_dataloader_state}"
     "save_every=${save_every}"
     "eval_every=${eval_every}"
     "log_every=${log_every}"


### PR DESCRIPTION
<!-- Policy submission PR — see CONTRIBUTING.md for the full standard.
     For non-policy changes, delete the sections that do not apply. -->

## Policy
- Name / paper / upstream repo:
- Supported: bench_name=..., env_cfg_type=..., action_type=...
- Training support: full | eval-only (training release ETA: ...)

## Components
- [ ] install.sh
- [ ] model.py (+ __init__.py)
- [ ] deploy.yml (protocol: ws, policy_name matches the directory)
- [ ] deploy.py aligned with demo_policy (or divergence explained)
- [ ] eval.sh + setup_eval_policy_server.sh + setup_eval_env_client.sh
- [ ] process_data.sh / train.sh (or eval-only, declared above)
- [ ] policy README with install / data / train / eval commands

## Testing
- [ ] bash -n + py_compile pass
- [ ] EVAL_ENV_TYPE=debug closed loop passes (paste the log tail)
- [ ] Simulator eval: task=..., success=... (if available)

## Checkpoint (required for leaderboard evaluation)
<download script, Hugging Face or ModelScope preferred>

## Limitations / notes
...
