### PR TITLE
Add G05 RoboDojo policy adapter

### DIFF
--- a/client_server/ws/model_client.py
+++ b/client_server/ws/model_client.py
@@ -3,9 +3,18 @@
 from __future__ import annotations
 
 import asyncio
+import os
+import time
 from typing import Any, cast
 
 from client_server.ws.protocol.client import PolicyEvalClient, PolicyEvalClientConfig
+
+
+# Keep the wire protocol backward compatible: a batch is carried as a regular
+# INFER observation with a namespaced marker.  Old single-observation calls are
+# unchanged, while batch-aware policy adapters can execute one real model batch.
+BATCH_OBSERVATIONS_KEY = "__xpolicylab_batch_observations__"
+BATCH_ENV_INDICES_KEY = "__xpolicylab_batch_env_indices__"
 
 
 class WsModelClient:
@@ -27,6 +36,10 @@ class WsModelClient:
         self._step = 0
         self._latest_obs: Any | None = None
         self._latest_obs_batch: list[Any] | None = None
+        self._batch_calls = 0
+        self._batch_metrics_every = max(
+            0, int(os.environ.get("ROBODOJO_BATCH_METRICS_EVERY", "10"))
+        )
         self._loop = asyncio.new_event_loop()
         self._client = client or PolicyEvalClient(
             PolicyEvalClientConfig(
@@ -95,18 +108,40 @@ class WsModelClient:
                 raise ValueError(
                     "get_action_batch requires a previous update_obs_batch call"
                 )
-            actions = []
-            for observation in observations:
-                response = self._loop.run_until_complete(
-                    self._client.infer(
-                        cast(dict[str, Any], observation),
-                        trial_id=self.trial_id,
-                        action_case_id=self.action_case_id,
-                        step=self._step,
-                    )
+            if not observations:
+                return []
+            env_idx_list = list(obs) if obs is not None else None
+            payload: dict[str, Any] = {BATCH_OBSERVATIONS_KEY: observations}
+            if env_idx_list is not None:
+                payload[BATCH_ENV_INDICES_KEY] = env_idx_list
+            started = time.perf_counter()
+            response = self._loop.run_until_complete(
+                self._client.infer(
+                    payload,
+                    trial_id=self.trial_id,
+                    action_case_id=self.action_case_id,
+                    step=self._step,
                 )
-                actions.append(response.payload.get("actions"))
+            )
+            e2e_ms = (time.perf_counter() - started) * 1000.0
             self._step += 1
+            self._batch_calls = getattr(self, "_batch_calls", 0) + 1
+            actions = response.payload.get("actions")
+            if not isinstance(actions, list) or len(actions) != len(observations):
+                raise RuntimeError(
+                    "batch policy response size mismatch: "
+                    f"expected {len(observations)}, got "
+                    f"{len(actions) if isinstance(actions, list) else type(actions).__name__}"
+                )
+            metrics_every = getattr(self, "_batch_metrics_every", 10)
+            if metrics_every and self._batch_calls % metrics_every == 0:
+                server_ms = float(response.payload.get("latency_ms", 0.0))
+                print(
+                    "[BatchV2] "
+                    f"calls={self._batch_calls} size={len(observations)} "
+                    f"server_ms={server_ms:.1f} e2e_ms={e2e_ms:.1f} "
+                    f"transport_ms={max(0.0, e2e_ms - server_ms):.1f}"
+                )
             return actions
 
         if func_name == "trial_end":

--- a/policy/G05/README.md
+++ b/policy/G05/README.md
@@ -1,49 +1,119 @@
 # G05 RoboDojo Adapter
 
-This adapter integrates the GitHub G0.5 checkout at
-`/efm-nas/efm-nas/group-jt/haoyu.zhang/GalaxeaVLA_github_port` with XPolicyLab. It does not use the vendored
-`policy/GalaxeaVLA/GalaxeaVLA` code.
+This directory contains the G05 policy adapter for RoboDojo evaluation through
+XPolicyLab.
 
-## Training
-
-Default training uses G0.5 task config:
-
-```bash
-cd /efm-nas/efm-nas/group-jt/haoyu.zhang/external/robodojo/XPolicyLab/policy/G05
-export ROBODOJO_LEROBOT_V30_ROOT=/efm-nas/efm-nas/group-jt/haoyu.zhang/external/robodojo/data/RoboDojo_lerobot_v30_video
-bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3,4,5,6,7
-```
-
-For the GitHub G0.5 launcher, use
-`/efm-nas/efm-nas/group-jt/haoyu.zhang/GalaxeaVLA_github_port/scripts/run/finetune_robodojo_arx_x5_joint.sh`.
-
-## Evaluation
-
-Set `G05_CKPT_PATH` to a G0.5 run directory or `.pt` checkpoint. Debug mode
-validates websocket wiring and action schema without the simulator:
-
-```bash
-cd /efm-nas/efm-nas/group-jt/haoyu.zhang/external/robodojo/XPolicyLab/policy/G05
-export EVAL_ENV_TYPE=debug
-export G05_CKPT_PATH=/path/to/g05/run/or/checkpoints/checkpoint
-bash eval.sh RoboDojo stack_bowls cotrain arx_x5 joint 0 0 0 \
-  /mlplatform/haoyu.zhang/g05_runtime/g05_venv_nas base
-```
-
-For simulator evaluation, unset `EVAL_ENV_TYPE` or set it to `sim` and make
-sure the RoboDojo evaluator-side repo with `env_cfg/`, `scripts/`, `src/`, and
-`task/` is mounted next to `XPolicyLab`.
+The adapter loads a G05 policy implementation from an external G05 checkout and
+serves it through the XPolicyLab websocket policy-server interface. RoboDojo
+simulation remains on the evaluator/client side.
 
 ## Checkpoint
 
-The submitted FM-only RoboDojo ARX X5 joint checkpoint and inference assets are hosted at:
+Download the released checkpoint package from Hugging Face:
 
-https://huggingface.co/XZHY528/g05
+```bash
+huggingface-cli download XZHY528/g05 \
+  g05_robodojo_fm_only_checkpoint.tar \
+  g05_robodojo_fm_only_checkpoint.tar.sha256 \
+  --local-dir ./checkpoints/g05
+```
 
-Download and extract `xpolicylab_g05_fm_only_checkpoint_20260724.tar`, then set `G05_CKPT_PATH` to the extracted `XPolicyLab/policy/G05/checkpoints/checkpoint` path before evaluation.
+Verify and unpack:
 
-Required sidecars included in the archive:
+```bash
+cd ./checkpoints/g05
+sha256sum -c g05_robodojo_fm_only_checkpoint.tar.sha256
+tar -xf g05_robodojo_fm_only_checkpoint.tar
+```
 
-- `.hydra/config.yaml`
-- `dataset_stats.json`
-- `action_tokenizer.pt`
+The extracted directory should contain the policy checkpoint and the associated
+G05 inference assets required by this adapter. When launching evaluation, point
+`G05_CKPT_PATH` to the extracted checkpoint directory or to the checkpoint file
+inside it:
+
+```bash
+export G05_CKPT_PATH=/path/to/extracted/g05/checkpoint
+```
+
+The public checkpoint filename intentionally does not encode the training step.
+
+## Runtime requirements
+
+Install the XPolicyLab-side adapter dependencies:
+
+```bash
+cd policy/G05
+export G05_PYTHON=/path/to/python
+bash install.sh
+```
+
+Then set these paths before training or evaluation:
+
+```bash
+export G05_ROOT=/path/to/GalaxeaVLA_or_G05_checkout
+export G05_PYTHON=/path/to/python
+```
+
+`G05_ROOT` must contain the G05 model/inference code used by the adapter.
+`G05_PYTHON` must point to a Python environment with the G05 runtime
+dependencies installed.
+
+The checkpoint package does not include a full Python runtime. Keep the G05
+runtime as a normal external checkout/environment and point the adapter to it
+with `G05_ROOT` and `G05_PYTHON`.
+
+## Evaluation
+
+Debug mode validates policy-server wiring and action schema without launching
+Isaac Sim:
+
+```bash
+cd policy/G05
+export EVAL_ENV_TYPE=debug
+export G05_CKPT_PATH=/path/to/extracted/g05/checkpoint
+bash eval.sh RoboDojo stack_bowls checkpoint arx_x5 joint 0 0 0 \
+  "$G05_PYTHON" base
+```
+
+Simulator-backed evaluation uses the same adapter entrypoint. Example:
+
+```bash
+cd policy/G05
+export G05_ROOT=/path/to/G05_checkout
+export G05_PYTHON=/path/to/python
+export G05_CKPT_PATH=/path/to/extracted/g05/checkpoint
+export ROBODOJO_G05_ACTION_SOURCE=fm
+
+bash eval.sh RoboDojo stack_bowls checkpoint arx_x5 joint 0 0 0 \
+  "$G05_PYTHON" sim
+```
+
+The positional arguments are:
+
+```text
+eval.sh <bench_name> <task_name> <ckpt_name> <env_cfg_type> <action_type> \
+  <seed> <policy_gpu_id> <env_gpu_id> <policy_python_or_env> <eval_env>
+```
+
+Use `ROBODOJO_G05_ACTION_SOURCE=fm` for FM-style continuous action inference,
+or `ROBODOJO_G05_ACTION_SOURCE=ar` for AR-style action decoding when evaluating
+a compatible checkpoint.
+
+For simulator evaluation, unset `EVAL_ENV_TYPE` or set it to `sim`, and run from
+a RoboDojo checkout where the evaluator-side directories `env_cfg/`, `scripts/`,
+`src/`, `task/`, and `Assets/` are available next to `XPolicyLab`.
+
+## Training
+
+Training is optional for evaluation. If training is needed, set the RoboDojo
+LeRobot v3.0 joint-action dataset path explicitly:
+
+```bash
+export ROBODOJO_LEROBOT_V30_ROOT=/path/to/RoboDojo_lerobot_v30_video
+export G05_ROOT=/path/to/G05_checkout
+export G05_PYTHON=/path/to/python
+cd policy/G05
+bash train.sh RoboDojo cotrain arx_x5 joint 0 0,1,2,3,4,5,6,7
+```
+
+The adapter currently targets RoboDojo `arx_x5` with `joint` actions.

--- a/policy/G05/deploy.py
+++ b/policy/G05/deploy.py
@@ -1,9 +1,69 @@
+import collections
+import os
+
+
+G05_HISTORY_OBSERVATIONS_KEY = "__g05_history_observations__"
+
+
+def _parse_g05_obs_offsets():
+    raw = os.environ.get("ROBODOJO_G05_OBS_OFFSETS", "0")
+    raw = raw.strip()
+    if raw.startswith("[") and raw.endswith("]"):
+        raw = raw[1:-1]
+    offsets = []
+    for item in raw.split(","):
+        item = item.strip()
+        if item:
+            offsets.append(int(item))
+    return offsets or [0]
+
+
+def _init_history_buffer():
+    offsets = _parse_g05_obs_offsets()
+    max_lag = max(0, -min(offsets))
+    return offsets, collections.defaultdict(lambda: collections.deque(maxlen=max_lag + 1))
+
+
+def _obs_with_g05_history(obs, history, offsets):
+    """Attach training-aligned sparse history to one current observation.
+
+    RoboDojo calls update_obs after every simulator action, but only calls
+    get_action after a policy chunk is exhausted. Server-side buffers therefore
+    see chunk-spaced observations, not frame-spaced observations. For G0.5
+    temporal models trained with offsets such as [-150, -100, -50, 0], the
+    client must keep frame-level history and send the selected frames explicitly.
+    Missing early frames are clamped to the first observed frame, matching the
+    dataset boundary behavior.
+    """
+    if offsets == [0]:
+        return obs
+    seq = list(history)
+    if not seq:
+        seq = [obs]
+    selected = []
+    for offset in offsets:
+        idx = len(seq) - 1 + int(offset)
+        if idx < 0:
+            idx = 0
+        elif idx >= len(seq):
+            idx = len(seq) - 1
+        selected.append(seq[idx])
+    wrapped = dict(obs)
+    wrapped[G05_HISTORY_OBSERVATIONS_KEY] = selected
+    return wrapped
+
+
 def eval_one_episode(TASK_ENV, model_client):
     model_client.call(func_name="reset")
+    offsets, history_by_env = _init_history_buffer()
 
     while not TASK_ENV.is_episode_end():
         obs = TASK_ENV.get_obs()
-        model_client.call(func_name="update_obs", obs=obs)
+        history_by_env["single"].append(obs)
+        model_client.call(
+            func_name="update_obs",
+            obs=_obs_with_g05_history(obs, history_by_env["single"], offsets),
+        )
         actions = model_client.call(func_name="get_action")
 
         for action_idx, action in enumerate(actions):
@@ -13,16 +73,29 @@ def eval_one_episode(TASK_ENV, model_client):
                 break
 
             obs = TASK_ENV.get_obs()
-            model_client.call(func_name="update_obs", obs=obs)
+            history_by_env["single"].append(obs)
+            model_client.call(
+                func_name="update_obs",
+                obs=_obs_with_g05_history(obs, history_by_env["single"], offsets),
+            )
 
 
 def eval_one_episode_batch(TASK_ENV, model_client):
     model_client.call(func_name="reset")
+    offsets, history_by_env = _init_history_buffer()
 
     while not TASK_ENV.is_episode_end():
         env_idx_list = TASK_ENV.get_running_env_idx_list()
         obs_list = TASK_ENV.get_obs_batch(env_idx_list)
-        model_client.call(func_name="update_obs_batch", obs=obs_list)
+        for env_idx, obs in zip(env_idx_list, obs_list):
+            history_by_env[env_idx].append(obs)
+        model_client.call(
+            func_name="update_obs_batch",
+            obs=[
+                _obs_with_g05_history(obs, history_by_env[env_idx], offsets)
+                for env_idx, obs in zip(env_idx_list, obs_list)
+            ],
+        )
         actions = model_client.call(func_name="get_action_batch", env_idx_list=env_idx_list)
 
         chunk_size = len(actions[0])
@@ -38,7 +111,13 @@ def eval_one_episode_batch(TASK_ENV, model_client):
 
             actions = [actions[i] for i in active_batch_idx]
             env_idx_list = [env_idx_list[i] for i in active_batch_idx]
+            obs_list = TASK_ENV.get_obs_batch(env_idx_list)
+            for env_idx, obs in zip(env_idx_list, obs_list):
+                history_by_env[env_idx].append(obs)
             model_client.call(
                 func_name="update_obs_batch",
-                obs=TASK_ENV.get_obs_batch(env_idx_list),
+                obs=[
+                    _obs_with_g05_history(obs, history_by_env[env_idx], offsets)
+                    for env_idx, obs in zip(env_idx_list, obs_list)
+                ],
             )

--- a/policy/G05/deploy.yml
+++ b/policy/G05/deploy.yml
@@ -11,7 +11,7 @@ action_type: joint
 action_dim: 14
 eval_batch: true
 
-g05_root: /efm-nas/efm-nas/group-jt/haoyu.zhang/GalaxeaVLA_github_port
+g05_root: null
 ckpt_path: null
 eval_embodiment: robodojo
 action_steps: 16

--- a/policy/G05/install.sh
+++ b/policy/G05/install.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+XPL_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+PYTHON_BIN="${G05_PYTHON:-$(command -v python3)}"
+
+if [[ -z "${PYTHON_BIN}" || ! -x "${PYTHON_BIN}" ]]; then
+  echo "Set G05_PYTHON to a valid Python executable." >&2
+  exit 2
+fi
+
+echo "[G05 install] python=${PYTHON_BIN}"
+echo "[G05 install] xpolicylab=${XPL_ROOT}"
+
+"${PYTHON_BIN}" -m pip install -U pip
+"${PYTHON_BIN}" -m pip install -e "${XPL_ROOT}"
+
+cat <<'EOF'
+
+G05 adapter-side XPolicyLab dependencies are installed.
+
+Before running evaluation, set:
+
+  export G05_ROOT=/path/to/G05_checkout
+  export G05_PYTHON=/path/to/python
+  export G05_CKPT_PATH=/path/to/extracted/g05/checkpoint
+
+G05_ROOT/G05_PYTHON must point to a G05 runtime environment that can import the
+G05 model code and its dependencies.
+EOF

--- a/policy/G05/model.py
+++ b/policy/G05/model.py
@@ -1,14 +1,18 @@
 from __future__ import annotations
 
+import collections
+import inspect
 import os
 import sys
 from pathlib import Path
 from typing import Any
 
 import numpy as np
+import torch
 
 from XPolicyLab.model_template import ModelTemplate
 from XPolicyLab.utils.process_data import (
+    decode_image_bit,
     get_batch_size,
     get_robot_action_dim_info,
     pack_robot_state,
@@ -22,6 +26,8 @@ IMAGE_CANDIDATES = {
     "cam_right_wrist": ("cam_right_wrist",),
 }
 BATCH_OBSERVATIONS_KEY = "__xpolicylab_batch_observations__"
+BATCH_ENV_INDICES_KEY = "__xpolicylab_batch_env_indices__"
+G05_HISTORY_OBSERVATIONS_KEY = "__g05_history_observations__"
 
 
 class Model(ModelTemplate):
@@ -47,12 +53,13 @@ class Model(ModelTemplate):
         self.batch_size = self._resolve_batch_size()
         self._obs: dict[str, Any] | None = None
         self._obs_batch: list[dict[str, Any]] = []
+        self._obs_batch_env_keys: list[Any] | None = None
+        self._history_buffers: dict[Any, dict[str, Any]] = {}
 
-        g05_root = Path(
-            model_cfg.get("g05_root")
-            or os.environ.get("G05_ROOT")
-            or "/efm-nas/efm-nas/group-jt/haoyu.zhang/GalaxeaVLA_github_port"
-        ).expanduser().resolve()
+        raw_g05_root = model_cfg.get("g05_root") or os.environ.get("G05_ROOT")
+        if not raw_g05_root:
+            raise ValueError("G05_ROOT or deploy.yml g05_root must be set to a G05 checkout")
+        g05_root = Path(str(raw_g05_root)).expanduser().resolve()
         if not g05_root.exists():
             raise FileNotFoundError(f"G0.5 repo not found: {g05_root}")
         for path in (g05_root / "src", g05_root):
@@ -109,6 +116,7 @@ class Model(ModelTemplate):
             filter_embodiment(cfg, self.embodiment_type)
 
         self._build_obs_dict = build_obs_dict
+        self._build_obs_accepts_buffers = _call_accepts_history_buffers(build_obs_dict)
         device = "cuda"
         self.policy, self.processor = setup(cfg, device=device)
         self.discrete_action = bool(
@@ -137,6 +145,7 @@ class Model(ModelTemplate):
             f"[G05] loaded ckpt={ckpt_path} run_dir={run_dir} "
             f"embodiment={self.embodiment_type} "
             f"inference_batch_size={self.inference_batch_size} "
+            f"num_obs_steps={getattr(self.processor, 'num_obs_steps', 1)} "
             f"action_source={self.action_source} "
             f"discrete_action={self.discrete_action} "
             f"continuous_action={self.continuous_action}"
@@ -188,12 +197,28 @@ class Model(ModelTemplate):
                 raise TypeError(f"{BATCH_OBSERVATIONS_KEY} must contain a list")
             self._obs = None
             self._obs_batch = list(observations)
+            env_keys = obs.get(BATCH_ENV_INDICES_KEY)
+            if env_keys is not None:
+                if not isinstance(env_keys, (list, tuple)):
+                    raise TypeError(f"{BATCH_ENV_INDICES_KEY} must contain a list")
+                if len(env_keys) != len(self._obs_batch):
+                    raise ValueError(
+                        f"{BATCH_ENV_INDICES_KEY} length={len(env_keys)} does not match "
+                        f"batch size={len(self._obs_batch)}"
+                    )
+                self._obs_batch_env_keys = list(env_keys)
+            else:
+                self._obs_batch_env_keys = None
             return
         self._obs = obs
         self._obs_batch = []
+        self._obs_batch_env_keys = None
 
     def update_obs_batch(self, obs_list):
         self._obs_batch = list(obs_list)
+        self._obs_batch_env_keys = [
+            self._env_key_from_obs(obs, fallback_idx=i) for i, obs in enumerate(self._obs_batch)
+        ]
 
     def get_action(self):
         if self._obs_batch:
@@ -209,41 +234,194 @@ class Model(ModelTemplate):
         if not obs_list:
             size = len(env_idx_list) if env_idx_list is not None else self.batch_size
             return [self.get_action() for _ in range(size)]
-        return self._predict_chunks(obs_list)
+        env_keys = (
+            list(env_idx_list)
+            if env_idx_list is not None
+            else self._obs_batch_env_keys
+        )
+        if env_keys is None:
+            env_keys = [
+                self._env_key_from_obs(obs, fallback_idx=i) for i, obs in enumerate(obs_list)
+            ]
+        else:
+            env_keys = list(env_keys)[: len(obs_list)]
+        return self._predict_chunks(obs_list, env_keys=env_keys)
 
     def reset(self):
         self._obs = None
         self._obs_batch = []
+        self._obs_batch_env_keys = None
+        self._history_buffers.clear()
 
     def _predict_chunk(self, obs: dict[str, Any]) -> list[dict[str, np.ndarray]]:
-        return self._predict_chunks([obs])[0]
+        return self._predict_chunks([obs], env_keys=[self._env_key_from_obs(obs, fallback_idx=0)])[0]
 
     def _predict_chunks(
-        self, observations: list[dict[str, Any]]
+        self, observations: list[dict[str, Any]], env_keys: list[Any] | None = None
     ) -> list[list[dict[str, np.ndarray]]]:
-        obs_dicts = [
-            self._build_obs_dict(self._to_g05_raw_obs(obs), self.processor)
-            for obs in observations
-        ]
+        if env_keys is None:
+            env_keys = [
+                self._env_key_from_obs(obs, fallback_idx=i) for i, obs in enumerate(observations)
+            ]
+        obs_dicts = []
+        for i, obs in enumerate(observations):
+            raw_obs = self._to_g05_raw_obs(obs)
+            explicit_history = self._explicit_history_buffers_from_obs(obs, raw_obs)
+            if explicit_history is None:
+                frame_buffers, state_buffers = self._update_history_buffers(env_keys[i], raw_obs)
+            else:
+                frame_buffers, state_buffers = explicit_history
+            if self._build_obs_accepts_buffers:
+                obs_dicts.append(
+                    self._build_obs_dict(
+                        raw_obs,
+                        self.processor,
+                        frame_buffers=frame_buffers,
+                        state_buffers=state_buffers,
+                    )
+                )
+            else:
+                if frame_buffers is not None or state_buffers is not None:
+                    raise RuntimeError(
+                        "G05 mem/history evaluation requires a G05_ROOT whose "
+                        "scripts.serve_policy.build_obs_dict accepts frame_buffers/state_buffers; "
+                        "use GalaxeaVLA_Private or another updated G0.5 repo."
+                    )
+                obs_dicts.append(self._build_obs_dict(raw_obs, self.processor))
         batch_size = max(1, int(getattr(self, "inference_batch_size", len(obs_dicts))))
         actions = []
         for start in range(0, len(obs_dicts), batch_size):
             actions.extend(self.inferencer.infer(obs_dicts[start : start + batch_size]))
         return [self._format_action_chunk(action) for action in actions]
 
+    def _explicit_history_buffers_from_obs(
+        self, obs: dict[str, Any], current_raw_obs: dict[str, Any]
+    ) -> tuple[dict[str, list[torch.Tensor]], dict[str, list[torch.Tensor]]] | None:
+        history = obs.get(G05_HISTORY_OBSERVATIONS_KEY) if isinstance(obs, dict) else None
+        num_obs_steps = int(getattr(self.processor, "num_obs_steps", 1))
+        if num_obs_steps <= 1 or not history:
+            return None
+
+        shape_meta = getattr(self.processor, "shape_meta", {}) or {}
+        expected_img_keys = {m["key"] for m in shape_meta.get("images", [])}
+        expected_state_keys = {m["key"] for m in shape_meta.get("state", [])}
+        if not expected_img_keys or not expected_state_keys:
+            return None
+
+        raw_history = [self._to_g05_raw_obs(item) for item in list(history)[-num_obs_steps:]]
+        if not raw_history:
+            raw_history = [current_raw_obs]
+        while len(raw_history) < num_obs_steps:
+            raw_history.insert(0, raw_history[0])
+
+        frames = {k: [] for k in expected_img_keys}
+        states = {k: [] for k in expected_state_keys}
+        for raw in raw_history[-num_obs_steps:]:
+            for k in expected_img_keys:
+                if k in raw["images"]:
+                    frames[k].append(torch.from_numpy(np.array(raw["images"][k], copy=True)))
+            for k in expected_state_keys:
+                if k in raw["state"]:
+                    states[k].append(torch.from_numpy(np.array(raw["state"][k], copy=True)).float())
+
+        if any(len(v) != num_obs_steps for v in frames.values()) or any(
+            len(v) != num_obs_steps for v in states.values()
+        ):
+            return None
+        return frames, states
+
+    def _env_key_from_obs(self, obs: dict[str, Any], fallback_idx: int | None = None) -> Any:
+        for key in ("env_idx", "env_id", "env_index"):
+            if isinstance(obs, dict) and key in obs:
+                return obs[key]
+        additional_info = obs.get("additional_info") if isinstance(obs, dict) else None
+        if isinstance(additional_info, dict):
+            for key in ("env_idx", "env_id", "env_index"):
+                if key in additional_info:
+                    return additional_info[key]
+        return "single" if fallback_idx is None else f"batch:{fallback_idx}"
+
+    def _update_history_buffers(
+        self, env_key: Any, raw_obs: dict[str, Any]
+    ) -> tuple[dict[str, collections.deque] | None, dict[str, collections.deque] | None]:
+        num_obs_steps = int(getattr(self.processor, "num_obs_steps", 1))
+        if num_obs_steps <= 1:
+            return None, None
+
+        shape_meta = getattr(self.processor, "shape_meta", {}) or {}
+        expected_img_keys = {m["key"] for m in shape_meta.get("images", [])}
+        expected_state_keys = {m["key"] for m in shape_meta.get("state", [])}
+        if not expected_img_keys or not expected_state_keys:
+            return None, None
+
+        entry = self._history_buffers.get(env_key)
+        if entry is None:
+            entry = {
+                "frames": {
+                    k: collections.deque(maxlen=num_obs_steps) for k in expected_img_keys
+                },
+                "states": {
+                    k: collections.deque(maxlen=num_obs_steps) for k in expected_state_keys
+                },
+                "initialized": False,
+                "num_obs_steps": num_obs_steps,
+            }
+            self._history_buffers[env_key] = entry
+        elif entry.get("num_obs_steps") != num_obs_steps:
+            entry["frames"] = {
+                k: collections.deque(maxlen=num_obs_steps) for k in expected_img_keys
+            }
+            entry["states"] = {
+                k: collections.deque(maxlen=num_obs_steps) for k in expected_state_keys
+            }
+            entry["initialized"] = False
+            entry["num_obs_steps"] = num_obs_steps
+
+        img_tensors = {
+            k: torch.from_numpy(np.array(v, copy=True))
+            for k, v in raw_obs["images"].items()
+            if k in expected_img_keys
+        }
+        state_tensors = {
+            k: torch.from_numpy(np.array(v, copy=True)).float()
+            for k, v in raw_obs["state"].items()
+            if k in expected_state_keys
+        }
+
+        if not entry["initialized"]:
+            for _ in range(num_obs_steps):
+                for k, t in img_tensors.items():
+                    entry["frames"][k].append(t.clone())
+                for k, t in state_tensors.items():
+                    entry["states"][k].append(t.clone())
+            entry["initialized"] = True
+        else:
+            for k, t in img_tensors.items():
+                entry["frames"][k].append(t)
+            for k, t in state_tensors.items():
+                entry["states"][k].append(t)
+
+        return entry["frames"], entry["states"]
+
     def _format_action_chunk(self, action) -> list[dict[str, np.ndarray]]:
         action.pop("_cot_text", None)
         action.pop("_absent_keys", None)
 
         parts = {key: _to_horizon_array(value) for key, value in action.items()}
-        horizon = min(self.action_steps, min(arr.shape[0] for arr in parts.values()))
+        left_key = "left_arm" if "left_arm" in parts else "left_control"
+        right_key = "right_arm" if "right_arm" in parts else "right_control"
+        required = [left_key, "left_gripper", right_key, "right_gripper"]
+        missing = [key for key in required if key not in parts]
+        if missing:
+            raise KeyError(f"G05 action output missing keys {missing}; available={sorted(parts)}")
+        horizon = min(self.action_steps, min(parts[key].shape[0] for key in required))
         result = []
         for t in range(horizon):
             packed = np.concatenate(
                 [
-                    parts["left_arm"][t],
+                    parts[left_key][t],
                     parts["left_gripper"][t],
-                    parts["right_arm"][t],
+                    parts[right_key][t],
                     parts["right_gripper"][t],
                 ],
                 axis=-1,
@@ -272,21 +450,54 @@ class Model(ModelTemplate):
             instruction = instruction[0] if instruction else ""
 
         additional_info = obs.get("additional_info") or {}
+        images = self._build_raw_images(obs)
+        state = self._build_raw_state(packed_state)
         return {
-            "images": {
-                "cam_high": self._extract_image(obs, "cam_high"),
-                "cam_left_wrist": self._extract_image(obs, "cam_left_wrist"),
-                "cam_right_wrist": self._extract_image(obs, "cam_right_wrist"),
-            },
-            "state": {
-                "left_arm": packed_state[0:6],
-                "left_gripper": packed_state[6:7],
-                "right_arm": packed_state[7:13],
-                "right_gripper": packed_state[13:14],
-            },
+            "images": images,
+            "state": state,
             "task": str(instruction),
             "frequency": float(additional_info.get("frequency", self.default_frequency)),
             "embodiment_type": self.embodiment_type,
+        }
+
+    def _build_raw_state(self, packed_state: np.ndarray) -> dict[str, np.ndarray]:
+        """Map RoboDojo joint-state names to the state keys expected by the active G05 processor."""
+        shape_meta = getattr(self.processor, "shape_meta", {}) or {}
+        expected = {m.get("key") for m in shape_meta.get("state", []) if isinstance(m, dict)}
+        if {"left_control", "left_gripper", "right_control", "right_gripper"}.issubset(expected):
+            return {
+                "left_control": packed_state[0:6],
+                "left_gripper": packed_state[6:7],
+                "right_control": packed_state[7:13],
+                "right_gripper": packed_state[13:14],
+            }
+        return {
+            "left_arm": packed_state[0:6],
+            "left_gripper": packed_state[6:7],
+            "right_arm": packed_state[7:13],
+            "right_gripper": packed_state[13:14],
+        }
+
+    def _build_raw_images(self, obs: dict[str, Any]) -> dict[str, np.ndarray]:
+        """Map RoboDojo camera names to the image keys expected by the active G05 processor.
+
+        Older G05 runs used RoboDojo-native keys:
+          cam_high, cam_left_wrist, cam_right_wrist
+        GalaxeaVLA_Private uses canonical schema keys:
+          exterior_rgb, left_wrist_rgb, right_wrist_rgb
+        """
+        shape_meta = getattr(self.processor, "shape_meta", {}) or {}
+        expected = {m.get("key") for m in shape_meta.get("images", []) if isinstance(m, dict)}
+        if {"exterior_rgb", "left_wrist_rgb", "right_wrist_rgb"}.issubset(expected):
+            return {
+                "exterior_rgb": self._extract_image(obs, "cam_high"),
+                "left_wrist_rgb": self._extract_image(obs, "cam_left_wrist"),
+                "right_wrist_rgb": self._extract_image(obs, "cam_right_wrist"),
+            }
+        return {
+            "cam_high": self._extract_image(obs, "cam_high"),
+            "cam_left_wrist": self._extract_image(obs, "cam_left_wrist"),
+            "cam_right_wrist": self._extract_image(obs, "cam_right_wrist"),
         }
 
     def _extract_image(self, obs: dict[str, Any], g05_key: str) -> np.ndarray:
@@ -313,7 +524,20 @@ def _step_sort_key(path: Path) -> int:
     return -1
 
 
+def _call_accepts_history_buffers(fn) -> bool:
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return False
+    params = sig.parameters
+    if "frame_buffers" in params and "state_buffers" in params:
+        return True
+    return any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+
 def _as_chw_uint8(value) -> np.ndarray:
+    if not isinstance(value, np.ndarray):
+        value = decode_image_bit(value)
     arr = np.asarray(value)
     if arr.ndim == 4:
         arr = arr[0]

--- a/policy/G05/setup_eval_policy_server.sh
+++ b/policy/G05/setup_eval_policy_server.sh
@@ -19,15 +19,13 @@ UTILS_DIR="${XPL_ROOT}/utils"
 policy_name="$(basename "${SCRIPT_DIR}")"
 yaml_file="${SCRIPT_DIR}/deploy.yml"
 
-G05_ROOT="${G05_ROOT:-/efm-nas/efm-nas/group-jt/haoyu.zhang/GalaxeaVLA_github_port}"
+G05_ROOT="${G05_ROOT:-}"
 PYTHON_BIN="${G05_PYTHON:-}"
 if [[ -z "${PYTHON_BIN}" ]]; then
   if [[ "${policy_env}" == /* && -x "${policy_env}/bin/python" ]]; then
     PYTHON_BIN="${policy_env}/bin/python"
   elif [[ -x "${policy_env}" ]]; then
     PYTHON_BIN="${policy_env}"
-  elif [[ -x "/mlplatform/haoyu.zhang/g05_runtime/g05_venv_nas/bin/python" ]]; then
-    PYTHON_BIN="/mlplatform/haoyu.zhang/g05_runtime/g05_venv_nas/bin/python"
   else
     PYTHON_BIN="$(command -v python3)"
   fi
@@ -50,7 +48,6 @@ resolve_ckpt_path() {
       "${SCRIPT_DIR}/checkpoints/${run_dir_name}"
       "${SCRIPT_DIR}/checkpoints/${raw}"
       "${G05_ROOT}/outputs/${run_dir_name}"
-      "/efm-nas/efm-nas/group-jt/haoyu.zhang/experiments_compare/results/robodojo/g05/github_robodojo_arx_x5_joint/robodojo_arx_x5_joint/${run_dir_name}"
     )
   fi
 
@@ -71,6 +68,11 @@ resolve_ckpt_path() {
 if [[ "${action_type}" != "joint" ]]; then
   echo "G05 adapter currently supports action_type=joint, got ${action_type}" >&2
   exit 2
+fi
+
+if [[ -z "${G05_ROOT}" ]]; then
+  echo "Set G05_ROOT to a G05 checkout before launching the G05 adapter." >&2
+  exit 3
 fi
 
 if [[ ! -d "${G05_ROOT}" ]]; then

--- a/policy/G05/train.sh
+++ b/policy/G05/train.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bench_name=${1:?bench_name required}
+ckpt_name=${2:?ckpt_name required}
+env_cfg_type=${3:?env_cfg_type required}
+action_type=${4:?action_type required}
+seed=${5:?seed required}
+gpu_id=${6:?gpu_id required}
+shift 6 || true
+
+if [[ "${action_type}" != "joint" ]]; then
+  echo "G05 train.sh currently supports action_type=joint, got ${action_type}" >&2
+  exit 2
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+G05_ROOT="${G05_ROOT:-}"
+PYTHON_BIN="${G05_PYTHON:-$(command -v python3)}"
+TASK_CONFIG="${G05_TASK_CONFIG:-robodojo_arx_x5_joint}"
+RUN_ID="${bench_name}-${ckpt_name}-${env_cfg_type}-${action_type}-${seed}"
+OUTPUT_ROOT="${G05_OUTPUT_ROOT:-${SCRIPT_DIR}/checkpoints}"
+export G05_OUTPUT_DIR="${G05_OUTPUT_DIR:-${OUTPUT_ROOT}}"
+export EXP_NAME="${EXP_NAME:-${RUN_ID}}"
+
+if [[ -z "${G05_ROOT}" ]]; then
+  echo "Set G05_ROOT to a G05 checkout before launching training." >&2
+  exit 3
+fi
+if [[ -z "${ROBODOJO_LEROBOT_V30_ROOT:-}" ]]; then
+  echo "Set ROBODOJO_LEROBOT_V30_ROOT to the RoboDojo LeRobot v3.0 dataset path." >&2
+  exit 3
+fi
+
+if [[ "${gpu_id}" == *","* ]]; then
+  IFS=',' read -r -a _gpus <<< "${gpu_id}"
+  num_gpus="${#_gpus[@]}"
+else
+  num_gpus=1
+fi
+
+export CUDA_VISIBLE_DEVICES="${gpu_id}"
+export PYTHONPATH="${G05_ROOT}:${PYTHONPATH:-}"
+export WANDB_PROJECT="${WANDB_PROJECT:-g05_robodojo_compare}"
+export WANDB_ENTITY="${WANDB_ENTITY:-zhanghaoyu913-south-china-university-of-technology}"
+export WANDB_BASE_URL="${WANDB_BASE_URL:-https://api.wandb.ai}"
+export WANDB_DIRECT="${WANDB_DIRECT:-1}"
+if [[ "${WANDB_DIRECT}" == "1" ]]; then
+  unset HTTP_PROXY HTTPS_PROXY ALL_PROXY http_proxy https_proxy all_proxy
+fi
+
+cd "${G05_ROOT}"
+export PYTHON_BIN
+exec bash scripts/run/finetune.sh \
+  "${num_gpus}" \
+  "${TASK_CONFIG}" \
+  "seed=${seed}" \
+  "logger.mode=online" \
+  "logger.project=${WANDB_PROJECT}" \
+  "logger.workspace=${WANDB_ENTITY}" \
+  "model.batch_size=${G05_BATCH_SIZE:-2}" \
+  "model.grad_accumulation_steps=${G05_GRAD_ACCUM:-1}" \
+  "$@"

--- a/utils/run_sim_env_client.sh
+++ b/utils/run_sim_env_client.sh
@@ -15,7 +15,9 @@ env_gpu_id="${11}"
 policy_server_ip="${12:-localhost}"
 protocol="${13:-ws}"
 
-source "$(conda info --base)/etc/profile.d/conda.sh"
+conda_exe="$(command -v conda)"
+conda_base="$(cd "$(dirname "${conda_exe}")/.." && pwd)"
+source "${conda_base}/etc/profile.d/conda.sh"
 conda deactivate || true
 conda activate "${eval_env_conda_env}"
 

--- a/utils/setup_env_client.sh
+++ b/utils/setup_env_client.sh
@@ -20,7 +20,15 @@ protocol_override="${14:-}"
 source "${UTILS_DIR}/resolve_eval_env_type.sh"
 eval_env_mode="$(resolve_eval_env_type)" || exit 1
 
-read eval_batch yaml_protocol < <(python - <<PY
+conda_exe="$(command -v conda)"
+conda_base="$(cd "$(dirname "${conda_exe}")/.." && pwd)"
+eval_python="${conda_base}/envs/${eval_env_conda_env}/bin/python"
+if [[ ! -x "${eval_python}" ]]; then
+    echo "[ERROR] Eval Python not found: ${eval_python}" >&2
+    exit 1
+fi
+
+read eval_batch yaml_protocol < <("${eval_python}" - <<PY
 import yaml
 with open("${yaml_file}", "r") as f:
     data = yaml.safe_load(f)


### PR DESCRIPTION
  ## Policy

  - Name / paper / upstream repo: G05 RoboDojo adapter
  - Supported: `bench_name=RoboDojo`, `env_cfg_type=arx_x5`, `action_type=joint`
  - Training support: full adapter support; checkpoint/runtime are hosted externally

  ## Components

  - [x] `install.sh`
  - [x] `model.py` (+ `__init__.py`)
  - [x] `deploy.yml` (`protocol: ws`, `policy_name: G05`)
  - [x] `deploy.py`
  - [x] `eval.sh` + `setup_eval_policy_server.sh` + `setup_eval_env_client.sh`
  - [x] `train.sh`
  - [x] policy README with install / checkpoint / train / eval commands

  ## Testing

  - [x] `bash -n policy/G05/install.sh policy/G05/eval.sh policy/G05/train.sh policy/G05/setup_eval_policy_server.sh policy/G05/
  setup_eval_env_client.sh`
  - [x] `python3 -m py_compile policy/G05/__init__.py policy/G05/deploy.py policy/G05/model.py`
  - [x] Checked selected PR files for private paths, tokens, IPs, and explicit checkpoint-step names.
  - [ ] `EVAL_ENV_TYPE=debug` closed loop log can be added after maintainer-side environment check.
  - [ ] Simulator eval log can be added after maintainer-side environment check.

  ## Checkpoint

  Checkpoint and required inference assets are hosted separately on Hugging Face:

  https://huggingface.co/XZHY528/g05

  Download:

  ```bash
  huggingface-cli download XZHY528/g05 \
    g05_robodojo_fm_only_checkpoint.tar \
    g05_robodojo_fm_only_checkpoint.tar.sha256 \
    --local-dir ./checkpoints/g05

  Verify and unpack:

  cd ./checkpoints/g05
  sha256sum -c g05_robodojo_fm_only_checkpoint.tar.sha256
  tar -xf g05_robodojo_fm_only_checkpoint.tar

  Then set:

  export G05_CKPT_PATH=/path/to/extracted/g05/checkpoint
  export G05_ROOT=/path/to/G05_checkout
  export G05_PYTHON=/path/to/python

  The public archive name intentionally does not encode the training step.

  ## Limitations / notes

  - Large checkpoint and inference assets are not committed to git.
  - The adapter expects an external G05 runtime checkout/environment through G05_ROOT and G05_PYTHON.
  - The adapter currently targets RoboDojo arx_x5 with joint actions.
  - Use ROBODOJO_G05_ACTION_SOURCE=fm for FM-style continuous action inference, or ROBODOJO_G05_ACTION_SOURCE=ar for compatible
    AR-style decoding.