### PR TITLE
Add G05 RoboDojo real-robot evaluation adapter

### DIFF
--- a/policy/G05/real/README.md
+++ b/policy/G05/real/README.md
@@ -1,0 +1,123 @@
+# G05 RoboDojo Real Evaluation
+
+**Contributor:** OpenGalaxea | **Runtime provenance:** documented in [`SOURCE.md`](SOURCE.md)
+
+This directory is the real-robot extension of the G05 XPolicyLab adapter. It is intentionally isolated from the RoboDojo simulation adapter in `policy/G05/`: it has its own deployment configuration, checkpoint layout, validation command, and server launcher. No file in this directory is used by simulation evaluation.
+
+Shared XPolicyLab conventions are documented in the [repository README](../../../README.md). Official results are published on the [RoboDojo LeaderBoard](https://robodojo-benchmark.com/LeaderBoard).
+
+## Scope
+
+- Evaluation only; the real-robot client is operated by RoboDojo and is not included.
+- Joint-position actions for `arx_x5`, `piper`, and `piper_x`.
+- One checkpoint per physical embodiment. A bundle is rejected when its saved embodiment does not match `env_cfg_type`.
+- Native 25 Hz observations and actions.
+- The checkpoint predicts 32 actions; the server returns the first 16 actions before the official client replans.
+- The released AR+FM checkpoint is deployed through its continuous FM head only.
+
+Only the ARX-X5 checkpoint is currently released and validated. Piper and Piper-X must not be evaluated with the ARX-X5 checkpoint.
+
+## Directory layout
+
+```text
+policy/G05/real/
+├── README.md
+├── SOURCE.md
+├── deploy.yml
+├── install.sh
+├── model.py
+├── setup_eval_policy_server.sh
+├── validate_bundle.py
+├── checkpoints/
+│   └── arx_x5/
+│       ├── config.yaml
+│       ├── .hydra/config.yaml
+│       ├── checkpoints/checkpoint.pt
+│       ├── dataset_stats.json
+│       ├── dataset_stats_robodojo_real_arx_x5_h32.json
+│       ├── input_processor/
+│       ├── action_tokenizer_hf/
+│       └── inference_runtime/   # version-matched inference-only G05 code
+└── configs/
+```
+
+## Model assets
+
+The validated ARX-X5 real bundle is published at
+[ModelScope: `ZhyRobert/g05-robodojo-real`](https://modelscope.cn/models/ZhyRobert/g05-robodojo-real/files).
+Download only the robot-specific `real/arx_x5` directory and place its contents in
+`policy/G05/real/checkpoints/arx_x5`:
+
+```bash
+cd XPolicyLab/policy/G05/real
+python -m pip install -U modelscope
+
+modelscope download --model ZhyRobert/g05-robodojo-real \
+  --include 'real/arx_x5/**' \
+  --local_dir checkpoints/modelscope
+
+mkdir -p checkpoints/arx_x5
+cp -a checkpoints/modelscope/real/arx_x5/. checkpoints/arx_x5/
+```
+
+The public weight name is `checkpoint.pt`. Its expected SHA-256 digest is:
+
+```text
+1b6d0003c8ba6ea200fdc29a34f94807f1c9c849e93d2f94c69974bdd98f9047  checkpoints/checkpoint.pt
+```
+
+The bundle also includes `SHA256SUMS`, which covers every distributed file. Verify all files from the bundle root:
+
+```bash
+cd checkpoints/arx_x5
+sha256sum --check SHA256SUMS
+cd ../..
+```
+
+Before starting a server, validate it:
+
+```bash
+"$G05_REAL_PYTHON" validate_bundle.py \
+  --bundle checkpoints/arx_x5 \
+  --embodiment robodojo_arx_x5
+```
+
+The old mixed-embodiment real archive is not compatible with this adapter.
+
+## Installation
+
+Download the model bundle first, then use Python 3.10 with a CUDA-enabled PyTorch environment:
+
+```bash
+cd XPolicyLab/policy/G05/real
+export G05_REAL_PYTHON=/path/to/python
+export G05_REAL_CHECKPOINT_PATH="$PWD/checkpoints/arx_x5"
+bash install.sh
+```
+
+The runtime distributed with the robot-specific model bundle is authoritative. `G05_ROOT` and the older vendored runtime under `policy/G05/G05` are deliberately not consulted.
+
+## Evaluation server
+
+RoboDojo operates the real-robot client. The contributor starts only the policy server:
+
+```bash
+cd XPolicyLab/policy/G05/real
+export G05_REAL_CHECKPOINT_PATH="$PWD/checkpoints/arx_x5"
+
+bash setup_eval_policy_server.sh \
+  RoboDojo put_objects_into_basket checkpoint \
+  arx_x5 joint 0 0 "$G05_REAL_PYTHON" 6061 0.0.0.0
+```
+
+The server imports `XPolicyLab.policy.G05.real.model`, checks the bundle against `robodojo_arx_x5`, loads the FM head, and serves websocket actions on port 6061.
+
+## Robot-specific bundles
+
+| `env_cfg_type` | Required saved embodiment | Status |
+| --- | --- | --- |
+| `arx_x5` | `robodojo_arx_x5` | trained and locally validated |
+| `piper` | `robodojo_piper` | configuration supported; checkpoint pending |
+| `piper_x` | `robodojo_piper_x` | configuration supported; checkpoint pending |
+
+Never point two robot names at one bundle. Normalization statistics, processor artifacts, and model weights are treated as one indivisible per-embodiment artifact.

--- a/policy/G05/real/SOURCE.md
+++ b/policy/G05/real/SOURCE.md
@@ -1,0 +1,18 @@
+# Model-bundle runtime provenance
+
+The robot-specific model bundle contains a minimal inference runtime derived from the OpenGalaxea G05 source snapshot:
+
+```text
+commit: 7f8f78e6a6632d167365cc385f5555f2bae686a0
+```
+
+The XPolicyLab adapter loads only the runtime shipped with the selected model bundle. It never loads `policy/G05/G05` or an arbitrary external `G05_ROOT`.
+
+The model bundle includes only the runtime surface needed to load and serve the released checkpoint:
+
+- the imported subset of `src/g05/`
+- `scripts/serve_policy.py`
+- `configs/model/g05.yaml`
+- the imported subsets of the checked-out `galaxea_dataset` and `galaxea_tokenizer` dependencies
+
+Training launchers, cluster configuration, datasets, checkpoints, logs, credentials, and internal storage paths are excluded.

--- a/policy/G05/real/configs/arx_x5.yml
+++ b/policy/G05/real/configs/arx_x5.yml
@@ -1,0 +1,8 @@
+env_cfg_type: arx_x5
+eval_embodiment: robodojo_arx_x5
+checkpoint_dir: checkpoints/arx_x5
+frequency: 25
+action_type: joint
+action_source: fm
+action_horizon: 32
+action_steps: 16

--- a/policy/G05/real/configs/piper.yml
+++ b/policy/G05/real/configs/piper.yml
@@ -1,0 +1,9 @@
+env_cfg_type: piper
+eval_embodiment: robodojo_piper
+checkpoint_dir: checkpoints/piper
+frequency: 25
+action_type: joint
+action_source: fm
+action_horizon: 32
+action_steps: 16
+checkpoint_status: pending

--- a/policy/G05/real/configs/piper_x.yml
+++ b/policy/G05/real/configs/piper_x.yml
@@ -1,0 +1,9 @@
+env_cfg_type: piper_x
+eval_embodiment: robodojo_piper_x
+checkpoint_dir: checkpoints/piper_x
+frequency: 25
+action_type: joint
+action_source: fm
+action_horizon: 32
+action_steps: 16
+checkpoint_status: pending

--- a/policy/G05/real/deploy.yml
+++ b/policy/G05/real/deploy.yml
@@ -1,0 +1,19 @@
+policy_name: G05.real
+protocol: ws
+host: localhost
+port: null
+bench_name: RoboDojo
+task_name: null
+env_cfg_type: arx_x5
+seed: null
+action_type: joint
+eval_batch: false
+
+checkpoint_path: null
+eval_embodiment: robodojo_arx_x5
+action_source: fm
+action_steps: 16
+frequency: 25
+inference_batch_size: 1
+ws_ping_timeout_s: 120.0
+ws_ping_interval_s: 120.0

--- a/policy/G05/real/install.sh
+++ b/policy/G05/real/install.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+XPL_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+PYTHON_BIN="${G05_REAL_PYTHON:-$(command -v python3)}"
+BUNDLE_ROOT="${G05_REAL_CHECKPOINT_PATH:-${SCRIPT_DIR}/checkpoints/arx_x5}"
+RUNTIME_ROOT="${BUNDLE_ROOT}/inference_runtime"
+
+[[ -x "${PYTHON_BIN}" ]] || { echo "set G05_REAL_PYTHON to a Python executable" >&2; exit 2; }
+[[ -d "${RUNTIME_ROOT}/src/g05" ]] || {
+  echo "missing inference runtime: ${RUNTIME_ROOT}" >&2
+  echo "download and extract the robot-specific model bundle first" >&2
+  exit 2
+}
+"${PYTHON_BIN}" -m pip install -e "${XPL_ROOT}"
+"${PYTHON_BIN}" -m pip install -e "${RUNTIME_ROOT}/third_party/galaxea_dataset"
+"${PYTHON_BIN}" -m pip install -e "${RUNTIME_ROOT}/third_party/galaxea_tokenizer"
+"${PYTHON_BIN}" -m pip install -e "${RUNTIME_ROOT}"

--- a/policy/G05/real/model.py
+++ b/policy/G05/real/model.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from XPolicyLab.model_template import ModelTemplate
+from XPolicyLab.utils.checkpoint_resolver import resolve_checkpoint_root
+from XPolicyLab.utils.process_data import (
+    get_robot_action_dim_info,
+    pack_robot_state,
+    unpack_robot_state,
+)
+
+
+IMAGE_KEYS = {
+    "exterior_rgb": ("cam_high", "cam_head", "cam_third_view"),
+    "left_wrist_rgb": ("cam_left_wrist",),
+    "right_wrist_rgb": ("cam_right_wrist",),
+}
+EMBODIMENT_BY_ROBOT = {
+    "arx_x5": "robodojo_arx_x5",
+    "piper": "robodojo_piper",
+    "piper_x": "robodojo_piper_x",
+}
+
+
+class Model(ModelTemplate):
+    """RoboDojo-real adapter for checkpoints produced by the current G05 runtime."""
+
+    def __init__(self, model_cfg):
+        self.model_cfg = model_cfg
+        self.action_type = str(model_cfg.get("action_type") or "")
+        if self.action_type != "joint":
+            raise ValueError(f"RoboDojo real requires action_type=joint, got {self.action_type!r}")
+
+        self.env_cfg_type = str(model_cfg.get("env_cfg_type") or "")
+        if self.env_cfg_type not in EMBODIMENT_BY_ROBOT:
+            raise ValueError(
+                f"unsupported RoboDojo real robot {self.env_cfg_type!r}; "
+                f"expected one of {sorted(EMBODIMENT_BY_ROBOT)}"
+            )
+        self.embodiment = str(model_cfg.get("eval_embodiment") or "")
+        expected = EMBODIMENT_BY_ROBOT[self.env_cfg_type]
+        if self.embodiment != expected:
+            raise ValueError(
+                f"env_cfg_type={self.env_cfg_type!r} requires "
+                f"eval_embodiment={expected!r}, got {self.embodiment!r}"
+            )
+
+        self.frequency = float(model_cfg.get("frequency"))
+        if self.frequency != 25.0:
+            raise ValueError(f"RoboDojo real is trained and served at 25 Hz, got {self.frequency:g}")
+        self.action_steps = int(model_cfg.get("action_steps"))
+        if not 1 <= self.action_steps <= 32:
+            raise ValueError(f"action_steps must be in [1, 32], got {self.action_steps}")
+        if str(model_cfg.get("action_source")) != "fm":
+            raise ValueError("this real submission is validated only with action_source=fm")
+
+        self.robot_action_dim_info = get_robot_action_dim_info(self.env_cfg_type)
+        self.inference_batch_size = max(1, int(model_cfg.get("inference_batch_size") or 1))
+        self.batch_size = self.inference_batch_size
+        self._obs: dict[str, Any] | None = None
+        self._obs_batch: list[dict[str, Any]] = []
+
+        policy_dir = Path(__file__).resolve().parent
+        checkpoint_root = resolve_checkpoint_root(
+            model_cfg,
+            policy_dir / "checkpoints",
+            policy_dir=policy_dir,
+        )
+        runtime_root = checkpoint_root / "inference_runtime"
+        if not (runtime_root / "src" / "g05").is_dir():
+            raise FileNotFoundError(
+                "G05 real bundle is missing inference_runtime/src/g05: "
+                f"{checkpoint_root}"
+            )
+        for path in (
+            runtime_root / "src",
+            runtime_root / "third_party" / "galaxea_dataset" / "src",
+            runtime_root / "third_party" / "galaxea_tokenizer" / "src",
+            runtime_root,
+        ):
+            sys.path.insert(0, str(path))
+        os.chdir(runtime_root)
+
+        checkpoint_path = _resolve_checkpoint_file(checkpoint_root)
+
+        from g05.models.g05.inferencer import PolicyInferencer
+        from g05.utils.checkpoint.ckpt_utils import find_run_dir, load_config_from_run_dir
+        from scripts.serve_policy import build_obs_dict, setup
+
+        run_dir = find_run_dir(str(checkpoint_path))
+        cfg = load_config_from_run_dir(
+            run_dir,
+            str(checkpoint_path),
+            [
+                "model.model_arch.discrete_action=false",
+                "model.model_arch.continuous_action=true",
+                "model.model_arch.return_continuous_action=true",
+                "model.processor.discrete_action=false",
+                f"eval_embodiment={self.embodiment}",
+            ],
+        )
+        _validate_checkpoint_contract(cfg, run_dir, self.embodiment)
+        self.policy, self.processor = setup(cfg, device="cuda")
+        if bool(self.policy.discrete_action) or not bool(self.policy.continuous_action):
+            raise ValueError("deployment must expose FM only: discrete=false, continuous=true")
+        self.inferencer = PolicyInferencer(self.policy, self.processor, device="cuda")
+        self._build_obs_dict = build_obs_dict
+        print(
+            f"[G05 real] robot={self.env_cfg_type} embodiment={self.embodiment} "
+            f"frequency={self.frequency:g}Hz action_steps={self.action_steps} "
+            f"checkpoint={checkpoint_path}"
+        )
+
+    def update_obs(self, obs):
+        self._obs = obs
+        self._obs_batch = []
+
+    def update_obs_batch(self, obs_list):
+        self._obs = None
+        self._obs_batch = list(obs_list)
+
+    def get_action(self):
+        if self._obs is None:
+            raise RuntimeError("update_obs must be called before get_action")
+        return self._predict([self._obs])[0]
+
+    def get_action_batch(self, env_idx_list=None):
+        if not self._obs_batch:
+            raise RuntimeError("update_obs_batch must be called before get_action_batch")
+        observations = self._obs_batch
+        if env_idx_list is not None and len(env_idx_list) != len(observations):
+            raise ValueError(
+                f"env_idx_list length={len(env_idx_list)} does not match "
+                f"observation batch={len(observations)}"
+            )
+        return self._predict(observations)
+
+    def reset(self):
+        self._obs = None
+        self._obs_batch = []
+
+    def _predict(self, observations: list[dict[str, Any]]):
+        prepared = [self._build_obs_dict(self._to_g05_obs(obs), self.processor) for obs in observations]
+        outputs = []
+        for start in range(0, len(prepared), self.inference_batch_size):
+            outputs.extend(self.inferencer.infer(prepared[start : start + self.inference_batch_size]))
+        return [self._format_action_chunk(output) for output in outputs]
+
+    def _to_g05_obs(self, obs: dict[str, Any]) -> dict[str, Any]:
+        packed = pack_robot_state(
+            obs,
+            self.action_type,
+            self.robot_action_dim_info,
+            source_type="obs",
+            state_type="state",
+        ).astype(np.float32)
+        instruction = obs.get("instruction")
+        if not isinstance(instruction, str) or not instruction.strip():
+            raise ValueError("RoboDojo real observation requires a non-empty instruction string")
+        additional_info = obs.get("additional_info") or {}
+        observed_frequency = float(additional_info.get("frequency", self.frequency))
+        if observed_frequency != self.frequency:
+            raise ValueError(
+                f"observation frequency={observed_frequency:g} does not match "
+                f"checkpoint frequency={self.frequency:g}"
+            )
+        return {
+            "images": {key: self._extract_image(obs, candidates) for key, candidates in IMAGE_KEYS.items()},
+            "state": {
+                "left_control": packed[0:6],
+                "left_gripper": packed[6:7],
+                "right_control": packed[7:13],
+                "right_gripper": packed[13:14],
+            },
+            "task": instruction,
+            "frequency": self.frequency,
+            "embodiment_type": self.embodiment,
+        }
+
+    @staticmethod
+    def _extract_image(obs: dict[str, Any], candidates: tuple[str, ...]) -> np.ndarray:
+        vision = obs.get("vision")
+        if not isinstance(vision, dict):
+            raise KeyError("observation is missing vision")
+        for name in candidates:
+            view = vision.get(name)
+            if isinstance(view, dict) and "color" in view:
+                return _as_chw_uint8(view["color"])
+        raise KeyError(f"missing camera image; tried {candidates}")
+
+    def _format_action_chunk(self, action: dict[str, Any]):
+        action = {key: value for key, value in action.items() if not key.startswith("_")}
+        required = ("left_control", "left_gripper", "right_control", "right_gripper")
+        missing = [key for key in required if key not in action]
+        if missing:
+            raise KeyError(f"G05 output missing {missing}; available={sorted(action)}")
+        parts = {key: _as_horizon(action[key]) for key in required}
+        horizon = min(self.action_steps, *(parts[key].shape[0] for key in required))
+        result = []
+        for index in range(horizon):
+            packed = np.concatenate([parts[key][index] for key in required]).astype(np.float32)
+            result.append(
+                unpack_robot_state(
+                    packed,
+                    self.action_type,
+                    self.robot_action_dim_info,
+                    source_type="obs",
+                )
+            )
+        return result
+
+
+def _resolve_checkpoint_file(root: Path) -> Path:
+    if root.is_file():
+        return root
+    candidates = [root / "checkpoints" / "checkpoint.pt", root / "checkpoint.pt"]
+    existing = [path for path in candidates if path.is_file()]
+    if len(existing) != 1:
+        raise FileNotFoundError(
+            f"checkpoint bundle must contain exactly one checkpoint.pt; checked {candidates}"
+        )
+    return existing[0]
+
+
+def _validate_checkpoint_contract(cfg, run_dir: Path, embodiment: str) -> None:
+    datasets = cfg.data.get("datasets")
+    if datasets is None or list(datasets) != [embodiment]:
+        raise ValueError(
+            f"checkpoint must contain exactly data.datasets.{embodiment}; "
+            f"got {list(datasets) if datasets is not None else None}"
+        )
+    if str(datasets[embodiment].embodiment) != embodiment:
+        raise ValueError("checkpoint dataset embodiment does not match the selected robot")
+    stats_path = run_dir / "dataset_stats.json"
+    if not stats_path.is_file():
+        raise FileNotFoundError(f"checkpoint bundle is missing {stats_path.name}")
+    stats = json.loads(stats_path.read_text(encoding="utf-8"))
+    if set(stats) != {embodiment}:
+        raise ValueError(f"dataset_stats.json keys must be [{embodiment!r}], got {sorted(stats)}")
+    if int(datasets[embodiment].action_size) != 32:
+        raise ValueError("checkpoint action horizon must be 32")
+
+
+def _as_chw_uint8(value: Any) -> np.ndarray:
+    array = np.asarray(value)
+    if array.ndim != 3:
+        raise ValueError(f"camera image must be 3D, got {array.shape}")
+    if array.shape[0] != 3 and array.shape[-1] == 3:
+        array = np.moveaxis(array, -1, 0)
+    if array.shape[0] != 3:
+        raise ValueError(f"camera image must have three RGB channels, got {array.shape}")
+    if array.dtype != np.uint8:
+        raise TypeError(f"camera image must be uint8 RGB, got {array.dtype}")
+    return np.ascontiguousarray(array)
+
+
+def _as_horizon(value: Any) -> np.ndarray:
+    array = np.asarray(value, dtype=np.float32)
+    while array.ndim > 2 and array.shape[0] == 1:
+        array = array[0]
+    if array.ndim == 1:
+        array = array[:, None]
+    if array.ndim != 2:
+        raise ValueError(f"action part must be [T,D], got {array.shape}")
+    return array

--- a/policy/G05/real/setup_eval_policy_server.sh
+++ b/policy/G05/real/setup_eval_policy_server.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+bench_name=${1:?bench_name required}
+task_name=${2:?task_name required}
+ckpt_name=${3:?ckpt_name required}
+env_cfg_type=${4:?env_cfg_type required}
+action_type=${5:?action_type required}
+seed=${6:?seed required}
+policy_gpu_id=${7:?policy_gpu_id required}
+policy_python=${8:?policy Python executable required}
+policy_server_port=${9:?policy_server_port required}
+policy_server_host=${10:-0.0.0.0}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+XPL_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+CHECKPOINT_PATH="${G05_REAL_CHECKPOINT_PATH:-${SCRIPT_DIR}/checkpoints/${env_cfg_type}}"
+RUNTIME_ROOT="${CHECKPOINT_PATH}/inference_runtime"
+
+case "${env_cfg_type}" in
+  arx_x5) embodiment=robodojo_arx_x5 ;;
+  piper) embodiment=robodojo_piper ;;
+  piper_x) embodiment=robodojo_piper_x ;;
+  *) echo "unsupported RoboDojo real robot: ${env_cfg_type}" >&2; exit 2 ;;
+esac
+
+[[ "${action_type}" == joint ]] || { echo "real policy requires action_type=joint" >&2; exit 2; }
+[[ -x "${policy_python}" ]] || { echo "invalid policy Python: ${policy_python}" >&2; exit 2; }
+
+"${policy_python}" "${SCRIPT_DIR}/validate_bundle.py" \
+  --bundle "${CHECKPOINT_PATH}" --embodiment "${embodiment}"
+
+exec env \
+  CUDA_VISIBLE_DEVICES="${policy_gpu_id}" \
+  PYTHONPATH="${XPL_ROOT}:${RUNTIME_ROOT}/src:${RUNTIME_ROOT}:${RUNTIME_ROOT}/third_party/galaxea_dataset/src:${RUNTIME_ROOT}/third_party/galaxea_tokenizer/src:${PYTHONPATH:-}" \
+  "${policy_python}" -u "${XPL_ROOT}/setup_policy_server.py" \
+    --config_path "${SCRIPT_DIR}/deploy.yml" \
+    --overrides \
+      host="${policy_server_host}" \
+      port="${policy_server_port}" \
+      bench_name="${bench_name}" \
+      task_name="${task_name}" \
+      ckpt_name="${ckpt_name}" \
+      env_cfg_type="${env_cfg_type}" \
+      seed="${seed}" \
+      action_type="${action_type}" \
+      checkpoint_path="${CHECKPOINT_PATH}" \
+      eval_embodiment="${embodiment}"

--- a/policy/G05/real/validate_bundle.py
+++ b/policy/G05/real/validate_bundle.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from omegaconf import OmegaConf
+
+NAMED_STATS_BY_EMBODIMENT = {
+    "robodojo_arx_x5": "dataset_stats_robodojo_real_arx_x5_h32.json",
+    "robodojo_piper": "dataset_stats_robodojo_real_piper_h32.json",
+    "robodojo_piper_x": "dataset_stats_robodojo_real_piper_x_h32.json",
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bundle", required=True)
+    parser.add_argument("--embodiment", required=True)
+    args = parser.parse_args()
+
+    root = Path(args.bundle).expanduser().resolve()
+    try:
+        named_stats_name = NAMED_STATS_BY_EMBODIMENT[args.embodiment]
+    except KeyError as exc:
+        raise ValueError(f"unsupported embodiment: {args.embodiment}") from exc
+    checkpoint = root / "checkpoints" / "checkpoint.pt"
+    config = root / ".hydra" / "config.yaml"
+    public_config = root / "config.yaml"
+    stats = root / "dataset_stats.json"
+    named_stats = root / named_stats_name
+    required = [
+        checkpoint,
+        config,
+        public_config,
+        stats,
+        named_stats,
+        root / "input_processor",
+        root / "action_tokenizer_hf",
+        root / "inference_runtime" / "src" / "g05",
+        root / "inference_runtime" / "scripts" / "serve_policy.py",
+        root / "inference_runtime" / "third_party" / "galaxea_dataset" / "src",
+        root / "inference_runtime" / "third_party" / "galaxea_tokenizer" / "src",
+    ]
+    missing = [str(path) for path in required if not path.exists()]
+    if missing:
+        raise FileNotFoundError(f"incomplete G05 real bundle; missing: {missing}")
+
+    cfg = OmegaConf.load(config)
+    if OmegaConf.to_container(cfg, resolve=False) != OmegaConf.to_container(
+        OmegaConf.load(public_config), resolve=False
+    ):
+        raise ValueError("config.yaml and .hydra/config.yaml differ")
+    datasets = cfg.data.get("datasets")
+    if datasets is None or list(datasets) != [args.embodiment]:
+        raise ValueError(
+            f"bundle must contain exactly data.datasets.{args.embodiment}; "
+            f"got {list(datasets) if datasets is not None else None}"
+        )
+    if str(datasets[args.embodiment].embodiment) != args.embodiment:
+        raise ValueError("dataset embodiment mismatch")
+    if int(datasets[args.embodiment].action_size) != 32:
+        raise ValueError("action horizon must be 32")
+    payload = json.loads(stats.read_text(encoding="utf-8"))
+    if set(payload) != {args.embodiment}:
+        raise ValueError(f"stats keys={sorted(payload)} do not match {args.embodiment}")
+    if json.loads(named_stats.read_text(encoding="utf-8")) != payload:
+        raise ValueError("named and flat dataset stats differ")
+    print(f"validated G05 real bundle: embodiment={args.embodiment} frequency=25Hz")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Policy
- Name: G05 RoboDojo real-robot adapter
- Supported: `bench_name=RoboDojo`, `env_cfg_type=arx_x5|piper|piper_x`, `action_type=joint`
- Training support: eval-only; RoboDojo operates the real-robot client

## Scope
- Adds only `policy/G05/real/`; the existing G05 simulation adapter is unchanged.
- Enforces one checkpoint, normalization bundle, and saved embodiment per physical robot.
- The currently released and validated bundle is ARX-X5 only.
- Uses native 25 Hz observations/actions, a 32-step predicted horizon, and returns the first 16 FM actions.

## Components
- [x] real-only `model.py` and `__init__.py`
- [x] `deploy.yml`
- [x] policy-server launcher
- [x] per-robot configuration for ARX-X5, Piper, and Piper-X
- [x] bundle validator
- [x] install and evaluation documentation

## Testing
- [x] `git diff --check`
- [x] Python compilation
- [x] shell syntax checks
- [x] sanitized bundle validation
- [x] checkpoint-backed FM forward pass using the distributed inference runtime
- [x] ModelScope LFS object hash verified against the local checkpoint

## Checkpoint
ARX-X5 real evaluation bundle:
https://modelscope.cn/models/ZhyRobert/g05-robodojo-real/files

Checkpoint SHA-256:
`1b6d0003c8ba6ea200fdc29a34f94807f1c9c849e93d2f94c69974bdd98f9047`

## Limitations / notes
- Piper and Piper-X configurations are present, but their robot-specific checkpoints are not yet released.
- The ARX-X5 checkpoint must not be used for Piper or Piper-X.
- The official real-robot client is not included in this contribution.
