### PR TITLE
docs(DP): fix conda env creation order in README installation steps

### DIFF
--- a/policy/DP/README.md
+++ b/policy/DP/README.md
@@ -9,9 +9,10 @@ Shared conventions — argument meanings, checkpoint naming, split-machine deplo
 ## Installation
 
 ```bash
+conda create -n dp python=3.10 -y
+conda activate dp
 cd XPolicyLab/policy/DP
 bash install.sh
-conda activate <policy_env>  # e.g. dp
 ```
 
 ## Data Processing


### PR DESCRIPTION
## Summary

The current `## Installation` section in `policy/DP/README.md` runs `bash install.sh` before `conda activate <policy_env>`. Since `install.sh` only runs `pip install` and has no conda environment logic, this would install all dependencies into whatever environment happens to be active (often the `base` environment) instead of the intended policy environment.

## Changes

- Add an explicit `conda create -n dp python=3.10 -y` step.
- Activate the environment before changing into the policy directory and running `install.sh`.
- Remove the now-redundant trailing `conda activate` line.

This matches the actual requirement that `install.sh` be executed inside the policy conda environment.
